### PR TITLE
Document scrapbook assets and ignore local images

### DIFF
--- a/assets/scrapbook/.gitignore
+++ b/assets/scrapbook/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files in this directory
+*
+# Except this file and README.md
+!.gitignore
+!README.md

--- a/assets/scrapbook/README.md
+++ b/assets/scrapbook/README.md
@@ -1,0 +1,5 @@
+# Scrapbook Assets
+
+Add your local scrapbook images to this directory.  Image files here are ignored by Git so they stay on your machine and aren't committed to the repository.
+
+To share a placeholder or notes, create a Markdown file instead of committing an image.


### PR DESCRIPTION
## Summary
- add README to `assets/scrapbook` explaining local-only images
- ignore all scrapbook images in git

## Testing
- `bundle exec jekyll build` *(fails: bundler could not find jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68938d4dc0e8832eb6030e9f197fc281