### PR TITLE
Add scrapbook gallery page with lightbox

### DIFF
--- a/_pages/scrapbook.md
+++ b/_pages/scrapbook.md
@@ -1,0 +1,37 @@
+---
+layout: page
+title: Scrapbook
+permalink: /scrapbook/
+description: A small gallery of images from my scrapbook.
+---
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/simplelightbox/2.14.1/simple-lightbox.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+
+<div class="gallery">
+  {% assign gallery = site.static_files | where_exp: "file", "file.path contains 'assets/scrapbook/'" %}
+  {% for file in gallery %}
+    <a href="{{ file.path | relative_url }}">
+      <img src="{{ file.path | relative_url }}" alt="Scrapbook image {{ forloop.index }}" loading="lazy">
+    </a>
+  {% endfor %}
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/simplelightbox/2.14.1/simple-lightbox.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var lightbox = new SimpleLightbox('.gallery a');
+  });
+</script>
+
+<style>
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+.gallery img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+</style>

--- a/assets/scrapbook/README.md
+++ b/assets/scrapbook/README.md
@@ -1,0 +1,4 @@
+# Scrapbook Images
+
+Place image files for the scrapbook gallery in this directory.
+These files are ignored by Git so they can remain private or large.


### PR DESCRIPTION
## Summary
- create `/scrapbook/` page that builds a gallery from images in `assets/scrapbook`
- enable a lightbox effect using SimpleLightbox and responsive grid styling
- document scrapbook image directory

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6893966316f4832eaaff52f3503712eb