### PR TITLE
Show recently created notes on home page

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -23,34 +23,22 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
   <p>Loading last location...</p>
 </div> -->
 
-<strong>My recently updated notes</strong>
+<strong>My recently created notes</strong>
 
-<!-- <h3>Recently Updated</h3> -->
 <ul>
-  {% assign all_notes = site.notes | sort: "last_modified_at_timestamp" | reverse %}
+  {% assign all_notes = site.notes | sort: "created_at_timestamp" | reverse %}
   {% assign count = 0 %}
   {% for note in all_notes %}
     {% unless note.path contains 'Concerts' %}
       {% if count < 5 %}
         <li>
-          {{ note.last_modified_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
+          {{ note.created_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
         </li>
         {% assign count = count | plus: 1 %}
       {% endif %}
     {% endunless %}
   {% endfor %}
 </ul>
-
-<!-- <h3>Recently Created</h3>
-<ul>
-  {% assign new_notes = site.notes | sort: "created_at_timestamp" | reverse %}
-  {% for note in new_notes limit: 5 %}
-    <li>
-      {{ note.created_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
-    </li>
-  {% endfor %}
-</ul>
--->
 <style>
   .wrapper {
     max-width: 46em;

--- a/_plugins/created_at_generator.rb
+++ b/_plugins/created_at_generator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+require 'time'
+
+module CreatedAt
+  class Generator < Jekyll::Generator
+    def generate(site)
+      notes = site.collections['notes'].docs
+      notes.each do |page|
+        timestamp = created_timestamp(page.path)
+        page.data['created_at'] = Time.parse(timestamp)
+        page.data['created_at_timestamp'] = timestamp
+      end
+    end
+
+    private
+
+    def created_timestamp(path)
+      escaped = Shellwords.escape(path)
+      ts = `git log --diff-filter=A --follow --format=%aI -1 -- #{escaped}`.strip
+      ts = File.ctime(path).utc.iso8601 if ts.empty?
+      ts
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- display latest notes based on creation date instead of last edit
- generate created_at metadata for notes via git

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6899ff534f14832ea511de2088691b50