### PR TITLE
Add evergreen page links to home page

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -15,6 +15,8 @@ When I'm in Rhode Island, I look after our 1754 farmhouse and roast coffee in my
 
 I'm rarely without a camera, and share my adventures on [Instagram](https://www.instagram.com/coopersmith) and [Glass](https://glass.photo/coop).
 
+I keep evergreen pages for [trips]({{ '/travels/' | relative_url }}), [concerts]({{ '/concerts/' | relative_url }}), and will add more topics over time.
+
 <div id="recently-played">
   <p>Loading recently played tracks...</p>
 </div>


### PR DESCRIPTION
## Summary
- highlight evergreen content from home page with links to trips and concerts

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689a77fb82dc832ea036c01a43e53cd0