### PR TITLE
Fix mobile responsive layout: prevent text overflow and increase font size

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -53,10 +53,12 @@ body {
   margin: 0 auto;
   padding: 4vh 6vw;
   overflow-x: hidden;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
   max-width: 720px;
-  
+
   @media (max-width: 600px) {
-    font-size: 16px;
+    font-size: 17px;
     line-height: 1.6;
     padding: 3vh 5vw;
   }


### PR DESCRIPTION
## Summary

Fixes two mobile responsive issues reported on the site:

1. **Text scrolling off screen** — The `body` had `overflow-x: hidden` but no word-wrapping rules, so long unbreakable strings (wikilinks, URLs) could push lines wider than the viewport, causing a slight horizontal scroll. Added `overflow-wrap: break-word` and `word-wrap: break-word` so long strings wrap.

2. **Text too small on mobile** — The `max-width: 600px` breakpoint dropped body text from `18px` to `16px`. Bumped to `17px` for better readability while staying slightly smaller than desktop.

`box-sizing: content-box` was intentionally left unchanged to avoid narrowing the desktop reading column.

## Testing

- `bundle exec jekyll build` succeeds
- Verified compiled `_site/styles.css` contains `overflow-wrap:break-word`, `word-wrap:break-word`, and the mobile `font-size:17px`

https://claude.ai/code/session_01EdMToWmS5jXptxxn7QPQMG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdMToWmS5jXptxxn7QPQMG)_