### PR TITLE
Fix mobile page overflow (grid blowout) and increase mobile font size

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -58,7 +58,7 @@ body {
   max-width: 720px;
 
   @media (max-width: 600px) {
-    font-size: 17px;
+    font-size: 18px;
     line-height: 1.6;
     padding: 3vh 5vw;
   }
@@ -442,12 +442,19 @@ nav {
 #notes-entry-container {
   display: grid;
   grid-gap: 2em;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
     "content";
 
   @media (min-width: 700px) {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-areas: "content";
+  }
+
+  // Allow grid children to shrink below their content's intrinsic width
+  // instead of forcing the column (and the whole page) wider than the viewport.
+  > * {
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #26. A screenshot revealed the real mobile bug: the **entire page rendered wider than the viewport** (every line clipped on the right, no padding, pinch-to-zoom-out required to see the rest) — not a simple word-wrap issue.

### Root cause
`#notes-entry-container` is `display: grid` but had **no `grid-template-columns`** for the default/mobile case, so the column defaulted to `auto` (max-content) sizing. A single wide token — a long footnote URL or link — sized the track to its intrinsic width, blowing the column (and the whole page) past the viewport. `overflow-wrap` doesn't shrink an intrinsic grid track, which is why the earlier change didn't fix it.

### Fix
- `grid-template-columns: minmax(0, 1fr)` (both default and ≥700px) so the column is capped at the container width.
- `min-width: 0` on grid children, allowing them to shrink below their content's intrinsic width so text wraps instead of overflowing.
- Bumped mobile body `font-size` to `18px` to match desktop (desktop sizing was reported as correct).

## Testing
- `jekyll build` succeeds
- Verified `_site/styles.css` contains `minmax(0, 1fr)`, `#notes-entry-container>*{min-width:0}`, and mobile `font-size:18px`

https://claude.ai/code/session_01EdMToWmS5jXptxxn7QPQMG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdMToWmS5jXptxxn7QPQMG)_