### PR TITLE
Track note creation dates via frontmatter or git history

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -23,34 +23,23 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
   <p>Loading last location...</p>
 </div> -->
 
-<strong>My recently updated notes</strong>
+<strong>My recently created notes</strong>
 
-<!-- <h3>Recently Updated</h3> -->
+<!-- <h3>Recently Created</h3> -->
 <ul>
-  {% assign all_notes = site.notes | sort: "last_modified_at_timestamp" | reverse %}
+  {% assign all_notes = site.notes | sort: "created_at_timestamp" | reverse %}
   {% assign count = 0 %}
   {% for note in all_notes %}
     {% unless note.path contains 'Concerts' %}
       {% if count < 5 %}
         <li>
-          {{ note.last_modified_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
+          {{ note.created_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
         </li>
         {% assign count = count | plus: 1 %}
       {% endif %}
     {% endunless %}
   {% endfor %}
 </ul>
-
-<!-- <h3>Recently Created</h3>
-<ul>
-  {% assign new_notes = site.notes | sort: "created_at_timestamp" | reverse %}
-  {% for note in new_notes limit: 5 %}
-    <li>
-      {{ note.created_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
-    </li>
-  {% endfor %}
-</ul>
--->
 <style>
   .wrapper {
     max-width: 46em;

--- a/_pages/tableofcontents.md
+++ b/_pages/tableofcontents.md
@@ -7,28 +7,17 @@ permalink: /tableofcontents/
 
 
 
-<strong>My recently updated notes</strong>
+<strong>My recently created notes</strong>
 
-<!-- <h3>Recently Updated</h3> -->
+<!-- <h3>Recently Created</h3> -->
 <ul>
-  {% assign recent_notes = site.notes | sort: "last_modified_at_timestamp" | reverse %}
+  {% assign recent_notes = site.notes | sort: "created_at_timestamp" | reverse %}
   {% for note in recent_notes limit: 500 %}
-    <li>
-      {{ note.last_modified_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
-    </li>
-  {% endfor %}
-</ul>
-
-<!-- <h3>Recently Created</h3>
-<ul>
-  {% assign new_notes = site.notes | sort: "created_at_timestamp" | reverse %}
-  {% for note in new_notes limit: 5 %}
     <li>
       {{ note.created_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a>
     </li>
   {% endfor %}
 </ul>
--->
 <style>
   .wrapper {
     max-width: 46em;

--- a/_plugins/last_modified_at_generator.rb
+++ b/_plugins/last_modified_at_generator.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'pathname'
+require 'time'
 require 'jekyll-last-modified-at'
 
 module Recents
@@ -12,7 +13,44 @@ module Recents
       items.each do |page|
         timestamp = Jekyll::LastModifiedAt::Determinator.new(site.source, page.path, '%FT%T%:z').to_s
         page.data['last_modified_at_timestamp'] = timestamp
+
+        created = created_at_for(site, page)
+        next unless created
+
+        page.data['created_at'] = created
+        page.data['created_at_timestamp'] = created.strftime('%FT%T%:z')
       end
+    end
+
+    private
+
+    # Determine when a note was created. Prefer an explicit `created` (or
+    # `date`) value in the front matter, otherwise fall back to the date of
+    # the file's first git commit.
+    def created_at_for(site, page)
+      explicit = page.data['created'] || page.data['date']
+      return to_time(explicit) if explicit
+
+      git_created_at(site, page.path)
+    end
+
+    def git_created_at(source, path)
+      Dir.chdir(source) do
+        output = `git log --diff-filter=A --follow --format=%aI -1 -- "#{path}" 2>/dev/null`.strip
+        return nil if output.empty?
+
+        Time.parse(output)
+      end
+    rescue StandardError
+      nil
+    end
+
+    def to_time(value)
+      return value if value.is_a?(Time)
+
+      Time.parse(value.to_s)
+    rescue StandardError
+      nil
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds creation date tracking to notes by extracting `created_at` metadata from either explicit frontmatter values or the date of a file's first git commit. The homepage and table of contents are updated to display notes sorted by creation date instead of last modification date.

## Changes

- **`_plugins/last_modified_at_generator.rb`**
  - Added `require 'time'` for time parsing
  - Implemented `created_at_for()` method that checks for explicit `created` or `date` frontmatter values, falling back to git history
  - Implemented `git_created_at()` to query the date of the first commit for a file using `git log --diff-filter=A`
  - Implemented `to_time()` helper to safely convert values to Time objects
  - Populates `page.data['created_at']` and `page.data['created_at_timestamp']` for each note

- **`_pages/index.md`**
  - Changed "My recently updated notes" heading to "My recently created notes"
  - Updated sort to use `created_at_timestamp` instead of `last_modified_at_timestamp`
  - Updated display to show `created_at` date instead of `last_modified_at`
  - Removed commented-out "Recently Created" section

- **`_pages/tableofcontents.md`**
  - Changed "My recently updated notes" heading to "My recently created notes"
  - Updated sort to use `created_at_timestamp` instead of `last_modified_at_timestamp`
  - Updated display to show `created_at` date instead of `last_modified_at`
  - Removed commented-out "Recently Created" section

## Implementation Details

The creation date detection uses a priority system:
1. Explicit `created` frontmatter value (if present)
2. Explicit `date` frontmatter value (if present)
3. Date of the file's first git commit (via `git log --diff-filter=A --follow`)

All time parsing is wrapped in error handling to gracefully handle missing git history or invalid date values.

https://claude.ai/code/session_01T4cC3JutbQ2dDjpB6Vu7xJ