### PR TITLE
Enable Foursquare last check-in on homepage

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -19,9 +19,7 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
   <p>Loading recently played tracks...</p>
 </div>
 
-<!-- <div id="last-checkin">
-  <p>Loading last location...</p>
-</div> -->
+<div id="last-checkin"></div>
 
 <strong>My recently created notes</strong>
 
@@ -47,4 +45,4 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
 </style>
 
 <script src="{{ site.baseurl }}/assets/js/lastfm.js"></script>
-<!-- <script src="{{ site.baseurl }}/assets/js/foursquare.js"></script> -->
+<script src="{{ site.baseurl }}/assets/js/foursquare.js"></script>

--- a/assets/js/foursquare.js
+++ b/assets/js/foursquare.js
@@ -13,16 +13,19 @@ async function getLastCheckin() {
     }
     
     const venueName = data.venue;
-    const location = data.location.city || data.location.neighborhood || '';
+    const loc = data.location || {};
+    const location = loc.city || loc.neighborhood || loc.state || '';
     const checkinTime = new Date(data.createdAt * 1000).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric'
     });
-    
-    document.getElementById('last-checkin').innerHTML = `Last checked in at ${venueName}${location ? ` in ${location}` : ''} on ${checkinTime}`;
+
+    document.getElementById('last-checkin').innerHTML = `<p>Last checked in at ${venueName}${location ? ` in ${location}` : ''} on ${checkinTime}</p>`;
   } catch (error) {
     console.error('Error fetching check-in data:', error);
-    document.getElementById('last-checkin').innerHTML = 'Unable to load check-in data';
+    // Fail quietly so the homepage never shows an error line.
+    const el = document.getElementById('last-checkin');
+    if (el) el.innerHTML = '';
   }
 }
 

--- a/netlify/functions/last-checkin.js
+++ b/netlify/functions/last-checkin.js
@@ -1,12 +1,32 @@
 export const handler = async () => {
-  const CLIENT_ID = process.env.FOURSQUARE_CLIENT_ID;
-  const CLIENT_SECRET = process.env.FOURSQUARE_CLIENT_SECRET;
-  const endpoint = `https://api.foursquare.com/v2/users/self/checkins?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&v=20250415&limit=1`;
+  // The /users/self/checkins endpoint is personal data, so it requires a
+  // user OAuth token (oauth_token=...), NOT the userless client_id/client_secret
+  // pair, which only works for public place lookups.
+  const OAUTH_TOKEN = process.env.FOURSQUARE_OAUTH_TOKEN;
+
+  if (!OAUTH_TOKEN) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Missing FOURSQUARE_OAUTH_TOKEN' })
+    };
+  }
+
+  const endpoint = `https://api.foursquare.com/v2/users/self/checkins?oauth_token=${OAUTH_TOKEN}&v=20250415&limit=1`;
 
   try {
     const response = await fetch(endpoint);
     const data = await response.json();
-    
+
+    // Foursquare returns its real status inside meta.code, even on a 200 HTTP
+    // response. Surface auth/rate-limit failures instead of treating them as
+    // "no check-ins found".
+    if (data.meta && data.meta.code !== 200) {
+      return {
+        statusCode: data.meta.code,
+        body: JSON.stringify({ error: data.meta.errorDetail || 'Foursquare API error' })
+      };
+    }
+
     if (!data.response || !data.response.checkins || !data.response.checkins.items.length) {
       return {
         statusCode: 404,
@@ -19,7 +39,9 @@ export const handler = async () => {
       statusCode: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': '*',
+        // Cache at the CDN for 10 min so page loads don't hammer the API.
+        'Cache-Control': 'public, max-age=0, s-maxage=600'
       },
       body: JSON.stringify({
         venue: checkin.venue.name,


### PR DESCRIPTION
Turns on the "last check-in" module that was already scaffolded in the repo but commented out and broken.

## Why it never worked
The Netlify function called Foursquare's `/users/self/checkins` using `client_id` + `client_secret`. That userless auth only works for public *place* lookups — personal "self" endpoints require a user OAuth token, so the call always failed and the module got commented out.

## Changes
- **`netlify/functions/last-checkin.js`** — use `FOURSQUARE_OAUTH_TOKEN` (`oauth_token` param) instead of client credentials; surface Foursquare's `meta.code` errors instead of masking them as "no check-ins"; cache the response at the CDN for 10 minutes.
- **`assets/js/foursquare.js`** — render venue + date wrapped in `<p>` to match the "recently listened" styling; fail silently (clear the element) so the homepage never shows an error line.
- **`_pages/index.md`** — uncomment the `#last-checkin` div and the `foursquare.js` script tag.

## Required config
`FOURSQUARE_OAUTH_TOKEN` must be set in Netlify env vars (done). The old `FOURSQUARE_CLIENT_ID` / `FOURSQUARE_CLIENT_SECRET` vars are no longer referenced and can be removed.

## Testing
Once the deploy preview builds, hit `/.netlify/functions/last-checkin` to confirm the token returns the latest check-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M69SpdAjcfsgfNpfmSiAKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M69SpdAjcfsgfNpfmSiAKQ)_