### PR TITLE
Update homepage Elsewhere links and add Media Diet index

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -38,10 +38,9 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
 <section class="home-section">
   <p class="home-label">Elsewhere</p>
   <ul class="home-list">
-    <li><a href="{{ site.baseurl }}/travels/">Travels</a> <span class="desc">— adventures and misadventures around the world.</span></li>
-    <li><a href="{{ site.baseurl }}/photos/">Photos</a> <span class="desc">— urban geometry, the farm, and Henry the lab.</span></li>
-    <li><a href="{{ site.baseurl }}/2025-reading-list/">Media Diet</a> <span class="desc">— what I'm reading, watching, and listening to.</span></li>
-    <li><a href="{{ site.baseurl }}/concerts">Concerts</a> <span class="desc">— shows I've caught, in roughly the order I caught them.</span></li>
+    <li><a href="{{ site.baseurl }}/travels/">Travels</a> <span class="desc">— adventures around the world.</span></li>
+    <li><a href="{{ site.baseurl }}/photos/">Visual Diary</a> <span class="desc">— my life through my lens.</span></li>
+    <li><a href="{{ site.baseurl }}/media/">Media Diet</a> <span class="desc">— what I'm reading, watching, and listening to.</span></li>
     <li><a href="{{ site.baseurl }}/about">About</a> <span class="desc">— the longer version, and where to find me.</span></li>
   </ul>
 </section>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -1,0 +1,92 @@
+---
+layout: page
+title: Media Diet
+id: media
+permalink: /media/
+---
+
+# Media Diet
+
+An index of what I've been reading, watching, and listening to — shows, movies, books, and the occasional year-in-review.
+
+<section class="media-section">
+  <p class="media-label">Year in review</p>
+  <ul class="media-list">
+    {% comment %}Top-level yearly recaps tagged mediadiet (or mediadiet/YYYY),
+       excluding individual entries that live in MediaDiet/ subfolders.{% endcomment %}
+    {% assign all_notes = site.notes | sort: "created_at_timestamp" | reverse %}
+    {% for note in all_notes %}
+      {% unless note.path contains 'MediaDiet/' %}
+        {% assign is_diet = false %}
+        {% for tag in note.tags %}
+          {% if tag contains 'mediadiet' %}{% assign is_diet = true %}{% endif %}
+        {% endfor %}
+        {% if is_diet %}
+          <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
+        {% endif %}
+      {% endunless %}
+    {% endfor %}
+  </ul>
+</section>
+
+<section class="media-section">
+  <p class="media-label">🎬 Movies</p>
+  <ul class="media-list">
+    {% assign movies = site.notes | where: "title", "Coop's 100 movies" | first %}
+    {% if movies %}
+      <li><a class="internal-link" href="{{ site.baseurl }}{{ movies.url }}">{{ movies.title }}</a></li>
+    {% endif %}
+  </ul>
+</section>
+
+<section class="media-section">
+  <p class="media-label">📚 Books</p>
+  <ul class="media-list">
+    {% assign books = site.notes | where_exp: "n", "n.path contains 'MediaDiet/Books'" | sort: "title" %}
+    {% for book in books %}
+      <li><a class="internal-link" href="{{ site.baseurl }}{{ book.url }}">{{ book.title }}</a></li>
+    {% endfor %}
+  </ul>
+</section>
+
+<style>
+  .wrapper { max-width: 46em; }
+
+  .media-section { margin-top: 2.5em; }
+
+  .media-label {
+    font-size: var(--text-caption);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+    color: var(--color-text-tertiary);
+    font-weight: var(--weight-medium);
+    margin: 0 0 0.9em;
+  }
+
+  .media-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .media-list li {
+    margin: 0;
+    line-height: var(--leading-relaxed);
+  }
+
+  .media-list li + li {
+    margin-top: 0.6em;
+  }
+
+  .media-list a {
+    text-decoration: none;
+    font-weight: var(--weight-medium);
+    color: var(--color-text-primary);
+    text-decoration-color: transparent;
+  }
+
+  .media-list a:hover {
+    text-decoration: underline;
+    text-decoration-color: var(--color-accent);
+  }
+</style>


### PR DESCRIPTION
## Summary

Refreshes the homepage **Elsewhere** list and introduces a dedicated Media Diet index at `/media/`.

### Homepage (`_pages/index.md`)
- **Travels** — trimmed to "adventures around the world" (dropped "and misadventures")
- **Photos** — renamed to **Visual Diary** ("my life through my lens")
- **Media Diet** — now links to the new `/media/` index (was `/2025-reading-list/`)
- **Concerts** — removed from the list (the `/concerts/` page itself is unchanged)
- **About** — unchanged

### New `/media/` index (`_pages/media.md`)
A hub for media consumed, styled to match the homepage, with three auto-populating sections:
- **Year in review** — yearly recaps auto-listed by the `mediadiet` tag (excludes individual entries living in `MediaDiet/` subfolders so books don't double-list)
- **🎬 Movies** — links to the "Coop's 100 movies" note
- **📚 Books** — auto-lists everything in `MediaDiet/Books/`

Sections populate from existing notes, so new entries flow in automatically.

### Note on verification
A full Jekyll build could not be run in the authoring environment (the git-sourced `jekyll-last-modified-at` gem is blocked by the egress policy, so `bundle install` can't complete). The Liquid was verified by hand against the actual note data; the Netlify deploy preview for this PR is the real render check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4eYfmBRWXgKJdC1U1ZLTR)_