### PR TITLE
Redesign Media Diet as a merged library with list/covers toggle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,3 +52,9 @@ defaults:
       path: "_photos/**/*.md"
     values:
       layout: "photo"
+  # Media notes (Books / Movies / Albums) use a richer frontmatter-driven
+  # layout. Listed after the _notes rule so it takes precedence.
+  - scope:
+      path: "_notes/MediaDiet/**/*.md"
+    values:
+      layout: "media"

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -1,0 +1,57 @@
+---
+layout: default
+---
+
+{%- assign type = 'Media' -%}
+{%- if page.path contains '/Books/' -%}{%- assign type = 'Book' -%}
+{%- elsif page.path contains '/Movies/' -%}{%- assign type = 'Movie' -%}
+{%- elsif page.path contains '/Albums/' -%}{%- assign type = 'Album' -%}
+{%- elsif page.path contains '/Shows/' or page.path contains '/TV/' -%}{%- assign type = 'Show' -%}
+{%- endif -%}
+{%- if page.type -%}{%- assign type = page.type -%}{%- endif -%}
+
+{%- assign clean_title = page.title | replace: '📚 ', '' | replace: '🎬 ', '' | replace: '📺 ', '' | replace: '🦖 ', '' -%}
+
+{%- assign creator = '' -%}{%- assign creator_label = 'By' -%}
+{%- if page.author -%}{%- assign creator = page.author | join: ', ' -%}{%- assign creator_label = 'Author' -%}
+{%- elsif page.director -%}{%- assign creator = page.director | join: ', ' -%}{%- assign creator_label = 'Director' -%}
+{%- elsif page.artist -%}{%- assign creator = page.artist | join: ', ' -%}{%- assign creator_label = 'Artist' -%}
+{%- endif -%}
+{%- assign creator = creator | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip -%}
+
+{%- assign genre = page.genre | join: ', ' | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip -%}
+{%- assign cast = page.cast | join: ', ' | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip -%}
+
+<article class="media-note">
+  <div class="media-note-head">
+    {%- if page.cover -%}
+    <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
+    {%- endif -%}
+    <div class="media-note-meta">
+      <span class="tag">{{ type }}</span>
+      <h1>{{ clean_title }}</h1>
+      <dl class="media-facts">
+        {%- if creator != '' -%}<dt>{{ creator_label }}</dt><dd>{{ creator }}</dd>{%- endif -%}
+        {%- if page.year -%}<dt>Year</dt><dd>{{ page.year }}</dd>{%- endif -%}
+        {%- if genre != '' -%}<dt>Genre</dt><dd>{{ genre }}</dd>{%- endif -%}
+        {%- if page.runtime -%}<dt>Runtime</dt><dd>{{ page.runtime }}</dd>{%- endif -%}
+        {%- if page.pages -%}<dt>Pages</dt><dd>{{ page.pages }}</dd>{%- elsif page.length -%}<dt>Pages</dt><dd>{{ page.length }}</dd>{%- endif -%}
+        {%- if cast != '' -%}<dt>Cast</dt><dd>{{ cast }}</dd>{%- endif -%}
+        {%- if page.rating -%}
+        <dt>Rating</dt>
+        <dd>{%- assign filled = page.rating -%}{%- if filled > 7 -%}{%- assign filled = 7 -%}{%- endif -%}{%- assign unfilled = 7 | minus: filled -%}<span class="rating-marks" title="{{ page.rating }}/7" aria-label="{{ page.rating }} out of 7">{%- if filled > 0 -%}{%- for i in (1..filled) -%}◆{%- endfor -%}{%- endif -%}{%- if unfilled > 0 -%}{%- for i in (1..unfilled) -%}◇{%- endfor -%}{%- endif -%}</span></dd>
+        {%- endif -%}
+      </dl>
+    </div>
+  </div>
+
+  {%- if page.plot -%}<p class="media-note-plot">{{ page.plot }}</p>{%- endif -%}
+
+  <div id="notes-entry-container" class="media-note-body">
+    <content>
+      {{ content }}
+    </content>
+  </div>
+
+  <p class="media-note-back"><a class="internal-link" href="{{ site.baseurl }}/media/">← Media Diet</a></p>
+</article>

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -24,14 +24,12 @@ layout: default
 
 <article class="media-note">
   <div class="media-note-head">
-    <div class="media-note-cover-col">
-      {%- if page.cover -%}
-      <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
-      {%- endif -%}
-      <span class="tag">{{ type }}</span>
-    </div>
+    {%- if page.cover -%}
+    <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
+    {%- endif -%}
     <div class="media-note-meta">
       <h1>{{ clean_title }}</h1>
+      <span class="tag media-note-type">{{ type }}</span>
       <dl class="media-facts">
         {%- if creator != '' -%}<dt>{{ creator_label }}</dt><dd>{{ creator }}</dd>{%- endif -%}
         {%- if page.year -%}<dt>Year</dt><dd>{{ page.year }}</dd>{%- endif -%}

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -24,11 +24,11 @@ layout: default
 
 <article class="media-note">
   <div class="media-note-head">
+    <span class="tag media-note-type">{{ type }}</span>
     {%- if page.cover -%}
     <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
     {%- endif -%}
     <div class="media-note-meta">
-      <span class="tag media-note-type">{{ type }}</span>
       <h1>{{ clean_title }}</h1>
       <dl class="media-facts">
         {%- if creator != '' -%}<dt>{{ creator_label }}</dt><dd>{{ creator }}</dd>{%- endif -%}

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -23,12 +23,12 @@ layout: default
 {%- assign cast = page.cast | join: ', ' | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip -%}
 
 <article class="media-note">
-  <span class="tag media-note-type">{{ type }}</span>
   <div class="media-note-head">
     {%- if page.cover -%}
     <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
     {%- endif -%}
     <div class="media-note-meta">
+      <span class="tag media-note-type">{{ type }}</span>
       <h1>{{ clean_title }}</h1>
       <dl class="media-facts">
         {%- if creator != '' -%}<dt>{{ creator_label }}</dt><dd>{{ creator }}</dd>{%- endif -%}

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -24,11 +24,13 @@ layout: default
 
 <article class="media-note">
   <div class="media-note-head">
-    {%- if page.cover -%}
-    <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
-    {%- endif -%}
-    <div class="media-note-meta">
+    <div class="media-note-cover-col">
+      {%- if page.cover -%}
+      <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
+      {%- endif -%}
       <span class="tag">{{ type }}</span>
+    </div>
+    <div class="media-note-meta">
       <h1>{{ clean_title }}</h1>
       <dl class="media-facts">
         {%- if creator != '' -%}<dt>{{ creator_label }}</dt><dd>{{ creator }}</dd>{%- endif -%}

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -23,13 +23,13 @@ layout: default
 {%- assign cast = page.cast | join: ', ' | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip -%}
 
 <article class="media-note">
+  <span class="tag media-note-type">{{ type }}</span>
   <div class="media-note-head">
     {%- if page.cover -%}
     <img class="media-note-cover" src="{{ page.cover }}" alt="Cover of {{ clean_title }}" loading="lazy">
     {%- endif -%}
     <div class="media-note-meta">
       <h1>{{ clean_title }}</h1>
-      <span class="tag media-note-type">{{ type }}</span>
       <dl class="media-facts">
         {%- if creator != '' -%}<dt>{{ creator_label }}</dt><dd>{{ creator }}</dd>{%- endif -%}
         {%- if page.year -%}<dt>Year</dt><dd>{{ page.year }}</dd>{%- endif -%}

--- a/_pages/concerts.md
+++ b/_pages/concerts.md
@@ -1,18 +1,22 @@
 ---
 title: Concerts and Live Music
-description: A running list of concerts attended
+description: A running list of concerts I've attended, with setlists where I have them.
 permalink: /concerts/
 ---
 
 <h1>Concerts</h1>
-<p class="subtitle">A running list of concerts I've attended, with setlists if available.</p>
+<p class="subtitle">A running list of concerts I've attended, with setlists where I have them.</p>
 
 {% assign concert_notes = site.notes | where_exp: "item", "item.tags contains 'concerts'" | sort: "Dates" | reverse %}
 <table class="index-table">
   {% for note in concert_notes %}
+    {% assign artists = note.Artists | join: ', ' | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
+    {% if artists == '' %}{% assign artists = note.title %}{% endif %}
+    {% assign venue = note.Venue | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
   <tr>
-    <td class="index-title"><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></td>
-    <td class="index-date muted">{{ note.Dates | date: "%B %-d, %Y" }}</td>
+    <td class="index-title"><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ artists }}</a></td>
+    <td class="index-meta muted">{{ venue }}</td>
+    <td class="index-date muted">{{ note.Dates | date: "%b %Y" }}</td>
   </tr>
   {% endfor %}
 </table>

--- a/_pages/concerts.md
+++ b/_pages/concerts.md
@@ -8,15 +8,28 @@ permalink: /concerts/
 <p class="subtitle">A running list of concerts I've attended, with setlists where I have them.</p>
 
 {% assign concert_notes = site.notes | where_exp: "item", "item.tags contains 'concerts'" | sort: "Dates" | reverse %}
+
+<div class="index-toolbar">
+  <span class="sort-control">
+    <label for="concerts-sort">Sort</label>
+    <select id="concerts-sort" class="sort-select" data-sort-scope=".index-table" data-sort-item="tr">
+      <option value="date">Date</option>
+      <option value="az">A→Z</option>
+    </select>
+  </span>
+</div>
+
 <table class="index-table">
   {% for note in concert_notes %}
     {% assign artists = note.Artists | join: ', ' | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
     {% if artists == '' %}{% assign artists = note.title %}{% endif %}
     {% assign venue = note.Venue | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
-  <tr>
+  <tr data-title="{{ artists | downcase | escape }}" data-date="{{ note.Dates | date: '%Y-%m-%d' }}">
     <td class="index-title"><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ artists }}</a></td>
     <td class="index-meta muted">{{ venue }}</td>
     <td class="index-date muted">{{ note.Dates | date: "%b %Y" }}</td>
   </tr>
   {% endfor %}
 </table>
+
+<script src="{{ site.baseurl }}/assets/js/sortable.js"></script>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -80,26 +80,7 @@ Everything I've been reading, watching, and listening to — in one place.
 <style>
   .wrapper { max-width: 46em; }
 
-  /* ---- Slash Packaging style tags ---- */
-  .tag {
-    display: inline-block;
-    border: 1px solid var(--color-border);
-    padding: 0.1em 0.55em 0.15em;
-    border-radius: 1em;
-    font-size: 0.75em;
-    line-height: 1.5;
-    color: var(--color-text-tertiary);
-    background: transparent;
-    text-decoration: none;
-    white-space: nowrap;
-  }
-  button.tag { font-family: inherit; cursor: pointer; }
-  button.tag:hover { color: var(--color-text-primary); border-color: var(--color-text-tertiary); }
-  button.tag.is-active {
-    color: var(--color-bg-primary);
-    background: var(--color-text-primary);
-    border-color: var(--color-text-primary);
-  }
+  /* `.tag` is defined globally (Slash Packaging style) in _sass/_style.scss */
 
   .media-toolbar {
     display: flex;

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -7,86 +7,208 @@ permalink: /media/
 
 # Media Diet
 
-An index of what I've been reading, watching, and listening to — shows, movies, books, and the occasional year-in-review.
+Everything I've been reading and watching, in one place.
 
-<section class="media-section">
-  <p class="media-label">Year in review</p>
+{% assign entries = site.notes | where_exp: "n", "n.cover" | where_exp: "n", "n.path contains 'MediaDiet/'" | sort: "created" | reverse %}
+
+<div class="media-toolbar">
+  <span class="media-count">{{ entries | size }} entries</span>
+  <div class="media-toggle" role="group" aria-label="View mode">
+    <button type="button" class="media-view-btn is-active" data-view="list">List</button>
+    <button type="button" class="media-view-btn" data-view="covers">Covers</button>
+  </div>
+</div>
+
+<div id="media-library" class="view-list">
+
   <ul class="media-list">
-    {% comment %}Top-level yearly recaps tagged mediadiet (or mediadiet/YYYY),
-       excluding individual entries that live in MediaDiet/ subfolders.{% endcomment %}
-    {% assign all_notes = site.notes | sort: "created_at_timestamp" | reverse %}
-    {% for note in all_notes %}
-      {% unless note.path contains 'MediaDiet/' %}
-        {% assign is_diet = false %}
-        {% for tag in note.tags %}
-          {% if tag contains 'mediadiet' %}{% assign is_diet = true %}{% endif %}
-        {% endfor %}
-        {% if is_diet %}
-          <li><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></li>
-        {% endif %}
-      {% endunless %}
+    {% for e in entries %}
+      {% assign type = 'Media' %}
+      {% if e.path contains '/Books/' %}{% assign type = 'Book' %}
+      {% elsif e.path contains '/Movies/' %}{% assign type = 'Movie' %}
+      {% elsif e.path contains '/Shows/' or e.path contains '/TV/' %}{% assign type = 'Show' %}
+      {% endif %}
+      {% if e.type %}{% assign type = e.type %}{% endif %}
+      {% assign clean_title = e.title | replace: '📚 ', '' | replace: '🎬 ', '' | replace: '📺 ', '' | replace: '🦖 ', '' %}
+      {% assign creator = '' %}
+      {% if e.author %}{% assign creator = e.author | join: ', ' | replace: '[[', '' | replace: ']]', '' %}
+      {% elsif e.director %}{% assign creator = e.director | join: ', ' | replace: '[[', '' | replace: ']]', '' %}{% endif %}
+      <li class="media-row">
+        <a class="internal-link media-row-title" href="{{ site.baseurl }}{{ e.url }}">{{ clean_title }}</a>
+        <span class="media-row-meta">
+          <span class="media-type media-type--{{ type | downcase }}">{{ type }}</span>
+          {% if creator != '' %}<span class="media-creator">{{ creator }}</span>{% endif %}
+          {% if e.year %}<span class="media-year">{{ e.year }}</span>{% endif %}
+          {% if e.rating %}<span class="media-rating">Rated {{ e.rating }}</span>{% endif %}
+        </span>
+      </li>
     {% endfor %}
   </ul>
-</section>
 
-<section class="media-section">
-  <p class="media-label">🎬 Movies</p>
-  <ul class="media-list">
-    {% assign movies = site.notes | where: "title", "Coop's 100 movies" | first %}
-    {% if movies %}
-      <li><a class="internal-link" href="{{ site.baseurl }}{{ movies.url }}">{{ movies.title }}</a></li>
-    {% endif %}
-  </ul>
-</section>
-
-<section class="media-section">
-  <p class="media-label">📚 Books</p>
-  <ul class="media-list">
-    {% assign books = site.notes | where_exp: "n", "n.path contains 'MediaDiet/Books'" | sort: "title" %}
-    {% for book in books %}
-      <li><a class="internal-link" href="{{ site.baseurl }}{{ book.url }}">{{ book.title }}</a></li>
+  <ul class="media-grid">
+    {% for e in entries %}
+      {% assign clean_title = e.title | replace: '📚 ', '' | replace: '🎬 ', '' | replace: '📺 ', '' | replace: '🦖 ', '' %}
+      <li class="media-card">
+        <a href="{{ site.baseurl }}{{ e.url }}" title="{{ clean_title }}">
+          <img class="media-cover" src="{{ e.cover }}" alt="Cover of {{ clean_title }}" loading="lazy" />
+          <span class="media-card-title">{{ clean_title }}</span>
+        </a>
+      </li>
     {% endfor %}
   </ul>
-</section>
+
+</div>
 
 <style>
   .wrapper { max-width: 46em; }
 
-  .media-section { margin-top: 2.5em; }
+  .media-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 2em 0 1.4em;
+    gap: 1em;
+  }
 
-  .media-label {
+  .media-count {
     font-size: var(--text-caption);
     text-transform: uppercase;
     letter-spacing: var(--tracking-caps);
     color: var(--color-text-tertiary);
     font-weight: var(--weight-medium);
-    margin: 0 0 0.9em;
   }
 
-  .media-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  .media-toggle {
+    display: inline-flex;
+    border: 1px solid var(--color-border, rgba(128,128,128,0.3));
+    border-radius: 999px;
+    overflow: hidden;
   }
 
-  .media-list li {
-    margin: 0;
-    line-height: var(--leading-relaxed);
+  .media-view-btn {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: var(--color-text-tertiary);
+    font: inherit;
+    font-size: var(--text-ui, 0.9em);
+    padding: 0.3em 0.9em;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
   }
 
-  .media-list li + li {
-    margin-top: 0.6em;
+  .media-view-btn.is-active {
+    background: var(--color-accent, #555);
+    color: #fff;
   }
 
-  .media-list a {
+  /* Toggle visibility driven by the container class */
+  .media-list, .media-grid { list-style: none; margin: 0; padding: 0; }
+
+  #media-library.view-list .media-grid { display: none; }
+  #media-library.view-covers .media-list { display: none; }
+
+  /* ---- List view ---- */
+  .media-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5em 0.7em;
+    padding: 0.55em 0;
+    border-bottom: 1px solid var(--color-border, rgba(128,128,128,0.12));
+  }
+
+  .media-row-title {
     text-decoration: none;
     font-weight: var(--weight-medium);
     color: var(--color-text-primary);
-    text-decoration-color: transparent;
   }
-
-  .media-list a:hover {
+  .media-row-title:hover {
     text-decoration: underline;
     text-decoration-color: var(--color-accent);
   }
+
+  .media-row-meta {
+    display: inline-flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.7em;
+    font-size: 0.9em;
+    color: var(--color-text-subtle);
+  }
+
+  .media-type {
+    font-size: 0.72em;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+    font-weight: var(--weight-medium);
+    color: var(--color-text-tertiary);
+    border: 1px solid var(--color-border, rgba(128,128,128,0.3));
+    border-radius: 4px;
+    padding: 0.05em 0.45em;
+  }
+
+  .media-year { font-variant-numeric: tabular-nums; }
+
+  /* ---- Covers view ---- */
+  .media-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 1.4em 1.1em;
+  }
+
+  .media-card a {
+    display: block;
+    text-decoration: none;
+    color: var(--color-text-secondary, var(--color-text-tertiary));
+  }
+
+  .media-cover {
+    display: block;
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+    border-radius: 4px;
+    background: var(--color-border, rgba(128,128,128,0.12));
+    box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+    transition: transform 0.15s ease;
+  }
+  .media-card a:hover .media-cover { transform: translateY(-3px); }
+
+  .media-card-title {
+    display: block;
+    margin-top: 0.5em;
+    font-size: 0.82em;
+    line-height: var(--leading-snug, 1.3);
+    color: var(--color-text-subtle);
+  }
+
+  @media (max-width: 600px) {
+    .media-grid { grid-template-columns: repeat(auto-fill, minmax(90px, 1fr)); }
+  }
 </style>
+
+<script>
+  (function () {
+    var lib = document.getElementById('media-library');
+    var btns = document.querySelectorAll('.media-view-btn');
+    if (!lib || !btns.length) return;
+
+    function setView(view) {
+      lib.classList.remove('view-list', 'view-covers');
+      lib.classList.add('view-' + view);
+      btns.forEach(function (b) {
+        b.classList.toggle('is-active', b.dataset.view === view);
+      });
+      try { localStorage.setItem('mediaView', view); } catch (e) {}
+    }
+
+    btns.forEach(function (b) {
+      b.addEventListener('click', function () { setView(b.dataset.view); });
+    });
+
+    var saved;
+    try { saved = localStorage.getItem('mediaView'); } catch (e) {}
+    if (saved === 'covers' || saved === 'list') setView(saved);
+  })();
+</script>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -18,9 +18,19 @@ Everything I've been reading, watching, and listening to — in one place.
     <button type="button" class="tag" data-filter="movie">Movies</button>
     <button type="button" class="tag" data-filter="album">Albums</button>
   </div>
-  <div class="media-toggle" role="group" aria-label="View mode">
-    <button type="button" class="media-view-btn is-active" data-view="list">List</button>
-    <button type="button" class="media-view-btn" data-view="covers">Covers</button>
+  <div class="media-toolbar-controls">
+    <span class="sort-control">
+      <label for="media-sort">Sort</label>
+      <select id="media-sort" class="sort-select" data-sort-scope="#media-library .media-list, #media-library .media-grid" data-sort-item="tr, li">
+        <option value="date">Date</option>
+        <option value="az">A→Z</option>
+        <option value="rating">Rating</option>
+      </select>
+    </span>
+    <div class="media-toggle" role="group" aria-label="View mode">
+      <button type="button" class="media-view-btn is-active" data-view="list">List</button>
+      <button type="button" class="media-view-btn" data-view="covers">Covers</button>
+    </div>
   </div>
 </div>
 
@@ -41,7 +51,10 @@ Everything I've been reading, watching, and listening to — in one place.
       {% elsif e.director %}{% assign creator = e.director | join: ', ' %}
       {% elsif e.artist %}{% assign creator = e.artist | join: ', ' %}{% endif %}
       {% assign creator = creator | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
-      <tr data-type="{{ type | downcase }}">
+      {% assign sorttitle = clean_title | downcase | strip %}
+      {% assign sortdate = '' %}
+      {% if e.created %}{% assign sortdate = e.created | date: '%Y-%m-%d' %}{% elsif e.last %}{% assign sortdate = e.last | date: '%Y-%m-%d' %}{% elsif e.year %}{% assign sortdate = e.year | append: '-00-00' %}{% endif %}
+      <tr data-type="{{ type | downcase }}" data-title="{{ sorttitle | escape }}" data-date="{{ sortdate }}" data-rating="{{ e.rating | default: 0 }}">
         <td class="index-title"><a class="internal-link" href="{{ site.baseurl }}{{ e.url }}">{{ clean_title }}</a></td>
         <td class="index-meta"><span class="tag">{{ type }}</span></td>
         <td class="index-meta muted">{{ creator }}</td>
@@ -61,7 +74,10 @@ Everything I've been reading, watching, and listening to — in one place.
       {% endif %}
       {% if e.type %}{% assign type = e.type %}{% endif %}
       {% assign clean_title = e.title | replace: '📚 ', '' | replace: '🎬 ', '' | replace: '📺 ', '' | replace: '🦖 ', '' %}
-      <li class="media-card" data-type="{{ type | downcase }}">
+      {% assign sorttitle = clean_title | downcase | strip %}
+      {% assign sortdate = '' %}
+      {% if e.created %}{% assign sortdate = e.created | date: '%Y-%m-%d' %}{% elsif e.last %}{% assign sortdate = e.last | date: '%Y-%m-%d' %}{% elsif e.year %}{% assign sortdate = e.year | append: '-00-00' %}{% endif %}
+      <li class="media-card" data-type="{{ type | downcase }}" data-title="{{ sorttitle | escape }}" data-date="{{ sortdate }}" data-rating="{{ e.rating | default: 0 }}">
         <a href="{{ site.baseurl }}{{ e.url }}" title="{{ clean_title }}">
           <img class="media-cover" src="{{ e.cover }}" alt="Cover of {{ clean_title }}" loading="lazy" />
           <span class="media-card-meta">
@@ -89,6 +105,7 @@ Everything I've been reading, watching, and listening to — in one place.
     margin: 2em 0 1.4em;
   }
   .media-filters { display: inline-flex; flex-wrap: wrap; gap: 0.4em; }
+  .media-toolbar-controls { display: inline-flex; align-items: center; gap: 0.9em; }
 
   .media-toggle {
     display: inline-flex;
@@ -168,3 +185,4 @@ Everything I've been reading, watching, and listening to — in one place.
     if (saved === 'covers' || saved === 'list') setView(saved);
   })();
 </script>
+<script src="{{ site.baseurl }}/assets/js/sortable.js"></script>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -46,7 +46,7 @@ Everything I've been reading, watching, and listening to — in one place.
         <td class="index-meta"><span class="tag">{{ type }}</span></td>
         <td class="index-meta muted">{{ creator }}</td>
         <td class="index-date muted">{% if e.year %}{{ e.year }}{% endif %}</td>
-        <td class="index-date muted media-rating">{%- if e.rating -%}{%- assign full = e.rating | divided_by: 2 -%}{%- assign half = e.rating | modulo: 2 -%}<span class="rating-stars" title="{{ e.rating }}/10" aria-label="{{ e.rating }} out of 10">{%- for i in (1..full) -%}★{%- endfor -%}{%- if half == 1 -%}½{%- endif -%}</span>{%- endif -%}</td>
+        <td class="index-date muted media-rating">{%- if e.rating -%}{%- assign filled = e.rating -%}{%- if filled > 7 -%}{%- assign filled = 7 -%}{%- endif -%}{%- assign unfilled = 7 | minus: filled -%}<span class="rating-marks" title="{{ e.rating }}/7" aria-label="{{ e.rating }} out of 7">{%- if filled > 0 -%}{%- for i in (1..filled) -%}◆{%- endfor -%}{%- endif -%}{%- if unfilled > 0 -%}{%- for i in (1..unfilled) -%}◇{%- endfor -%}{%- endif -%}</span>{%- endif -%}</td>
       </tr>
     {% endfor %}
   </table>
@@ -110,6 +110,8 @@ Everything I've been reading, watching, and listening to — in one place.
   #media-library.view-list .media-grid { display: none; }
   #media-library.view-covers .media-list { display: none; }
   .is-hidden { display: none !important; }
+
+  .rating-marks { letter-spacing: 0.12em; white-space: nowrap; font-size: 0.92em; }
 
   /* ---- Covers view ---- */
   .media-grid {

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -26,7 +26,7 @@ Everything I've been reading, watching, and listening to — in one place.
 
 <div id="media-library" class="view-list">
 
-  <ul class="media-list">
+  <table class="index-table media-list">
     {% for e in entries %}
       {% assign type = 'Media' %}
       {% if e.path contains '/Books/' %}{% assign type = 'Book' %}
@@ -41,17 +41,15 @@ Everything I've been reading, watching, and listening to — in one place.
       {% elsif e.director %}{% assign creator = e.director | join: ', ' %}
       {% elsif e.artist %}{% assign creator = e.artist | join: ', ' %}{% endif %}
       {% assign creator = creator | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
-      <li class="media-row" data-type="{{ type | downcase }}">
-        <a class="internal-link media-row-title" href="{{ site.baseurl }}{{ e.url }}">{{ clean_title }}</a>
-        <span class="media-row-meta">
-          <span class="tag">{{ type }}</span>
-          {% if creator != '' %}<span class="media-creator">{{ creator }}</span>{% endif %}
-          {% if e.year %}<span class="media-year">{{ e.year }}</span>{% endif %}
-          {% if e.rating %}<span class="media-rating">★ {{ e.rating }}</span>{% endif %}
-        </span>
-      </li>
+      <tr data-type="{{ type | downcase }}">
+        <td class="index-title"><a class="internal-link" href="{{ site.baseurl }}{{ e.url }}">{{ clean_title }}</a></td>
+        <td class="index-meta"><span class="tag">{{ type }}</span></td>
+        <td class="index-meta muted">{{ creator }}</td>
+        <td class="index-date muted">{% if e.year %}{{ e.year }}{% endif %}</td>
+        <td class="index-date muted media-rating">{% if e.rating %}★ {{ e.rating }}{% endif %}</td>
+      </tr>
     {% endfor %}
-  </ul>
+  </table>
 
   <ul class="media-grid">
     {% for e in entries %}
@@ -106,28 +104,12 @@ Everything I've been reading, watching, and listening to — in one place.
   }
   .media-view-btn.is-active { background: var(--color-text-primary); color: var(--color-bg-primary); }
 
-  .media-list, .media-grid { list-style: none; margin: 0; padding: 0; }
+  .media-grid { list-style: none; margin: 0; padding: 0; }
+  /* List view is a shared .index-table; sit it right under the toolbar */
+  .media-list.index-table { margin: 0; }
   #media-library.view-list .media-grid { display: none; }
   #media-library.view-covers .media-list { display: none; }
   .is-hidden { display: none !important; }
-
-  /* ---- List view ---- */
-  .media-row {
-    display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5em 0.7em;
-    padding: 0.6em 0;
-    border-bottom: 1px solid var(--color-border);
-  }
-  .media-row-title {
-    text-decoration: none; font-weight: var(--weight-medium);
-    color: var(--color-text-primary);
-  }
-  .media-row-title:hover { text-decoration: underline; text-decoration-color: var(--color-accent); }
-  .media-row-meta {
-    display: inline-flex; align-items: baseline; flex-wrap: wrap; gap: 0.6em;
-    font-size: 0.9em; color: var(--color-text-subtle);
-  }
-  .media-year { font-variant-numeric: tabular-nums; }
-  .media-rating { color: var(--color-text-tertiary); }
 
   /* ---- Covers view ---- */
   .media-grid {

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -46,7 +46,7 @@ Everything I've been reading, watching, and listening to — in one place.
         <td class="index-meta"><span class="tag">{{ type }}</span></td>
         <td class="index-meta muted">{{ creator }}</td>
         <td class="index-date muted">{% if e.year %}{{ e.year }}{% endif %}</td>
-        <td class="index-date muted media-rating">{% if e.rating %}★ {{ e.rating }}{% endif %}</td>
+        <td class="index-date muted media-rating">{%- if e.rating -%}{%- assign full = e.rating | divided_by: 2 -%}{%- assign half = e.rating | modulo: 2 -%}<span class="rating-stars" title="{{ e.rating }}/10" aria-label="{{ e.rating }} out of 10">{%- for i in (1..full) -%}★{%- endfor -%}{%- if half == 1 -%}½{%- endif -%}</span>{%- endif -%}</td>
       </tr>
     {% endfor %}
   </table>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -111,8 +111,6 @@ Everything I've been reading, watching, and listening to — in one place.
   #media-library.view-covers .media-list { display: none; }
   .is-hidden { display: none !important; }
 
-  .rating-marks { letter-spacing: 0.12em; white-space: nowrap; font-size: 0.92em; }
-
   /* ---- Covers view ---- */
   .media-grid {
     display: grid;

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -13,10 +13,10 @@ Everything I've been reading, watching, and listening to — in one place.
 
 <div class="media-toolbar">
   <div class="media-filters" role="group" aria-label="Filter by type">
-    <button type="button" class="media-chip is-active" data-filter="all">All</button>
-    <button type="button" class="media-chip media-chip--book" data-filter="book">Books</button>
-    <button type="button" class="media-chip media-chip--movie" data-filter="movie">Movies</button>
-    <button type="button" class="media-chip media-chip--album" data-filter="album">Albums</button>
+    <button type="button" class="tag is-active" data-filter="all">All</button>
+    <button type="button" class="tag" data-filter="book">Books</button>
+    <button type="button" class="tag" data-filter="movie">Movies</button>
+    <button type="button" class="tag" data-filter="album">Albums</button>
   </div>
   <div class="media-toggle" role="group" aria-label="View mode">
     <button type="button" class="media-view-btn is-active" data-view="list">List</button>
@@ -44,7 +44,7 @@ Everything I've been reading, watching, and listening to — in one place.
       <li class="media-row" data-type="{{ type | downcase }}">
         <a class="internal-link media-row-title" href="{{ site.baseurl }}{{ e.url }}">{{ clean_title }}</a>
         <span class="media-row-meta">
-          <span class="media-type media-type--{{ type | downcase }}">{{ type }}</span>
+          <span class="tag">{{ type }}</span>
           {% if creator != '' %}<span class="media-creator">{{ creator }}</span>{% endif %}
           {% if e.year %}<span class="media-year">{{ e.year }}</span>{% endif %}
           {% if e.rating %}<span class="media-rating">★ {{ e.rating }}</span>{% endif %}
@@ -65,11 +65,11 @@ Everything I've been reading, watching, and listening to — in one place.
       {% assign clean_title = e.title | replace: '📚 ', '' | replace: '🎬 ', '' | replace: '📺 ', '' | replace: '🦖 ', '' %}
       <li class="media-card" data-type="{{ type | downcase }}">
         <a href="{{ site.baseurl }}{{ e.url }}" title="{{ clean_title }}">
-          <span class="media-cover-wrap">
-            <img class="media-cover" src="{{ e.cover }}" alt="Cover of {{ clean_title }}" loading="lazy" />
-            <span class="media-type media-type--{{ type | downcase }} media-type--corner">{{ type }}</span>
+          <img class="media-cover" src="{{ e.cover }}" alt="Cover of {{ clean_title }}" loading="lazy" />
+          <span class="media-card-meta">
+            <span class="media-card-title">{{ clean_title }}</span>
+            <span class="tag">{{ type }}</span>
           </span>
-          <span class="media-card-title">{{ clean_title }}</span>
         </a>
       </li>
     {% endfor %}
@@ -80,13 +80,25 @@ Everything I've been reading, watching, and listening to — in one place.
 <style>
   .wrapper { max-width: 46em; }
 
-  /* Per-type accent colors */
-  #media-library, .media-toolbar {
-    --type-book: #2a9d8f;
-    --type-movie: #e76f51;
-    --type-album: #6a67ce;
-    --type-show: #e9c46a;
-    --type-media: var(--color-text-tertiary);
+  /* ---- Slash Packaging style tags ---- */
+  .tag {
+    display: inline-block;
+    border: 1px solid var(--color-border);
+    padding: 0.1em 0.55em 0.15em;
+    border-radius: 1em;
+    font-size: 0.75em;
+    line-height: 1.5;
+    color: var(--color-text-tertiary);
+    background: transparent;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  button.tag { font-family: inherit; cursor: pointer; }
+  button.tag:hover { color: var(--color-text-primary); border-color: var(--color-text-tertiary); }
+  button.tag.is-active {
+    color: var(--color-bg-primary);
+    background: var(--color-text-primary);
+    border-color: var(--color-text-primary);
   }
 
   .media-toolbar {
@@ -94,61 +106,24 @@ Everything I've been reading, watching, and listening to — in one place.
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: 0.8em 1em;
+    gap: 0.7em 1em;
     margin: 2em 0 1.4em;
   }
-
   .media-filters { display: inline-flex; flex-wrap: wrap; gap: 0.4em; }
-
-  .media-chip {
-    appearance: none;
-    border: 1px solid var(--color-border, rgba(128,128,128,0.3));
-    background: transparent;
-    color: var(--color-text-tertiary);
-    font: inherit;
-    font-size: 0.82em;
-    padding: 0.25em 0.75em;
-    border-radius: 999px;
-    cursor: pointer;
-    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
-  }
-  .media-chip:hover { color: var(--color-text-primary); }
-  .media-chip.is-active { background: var(--color-text-primary); color: var(--color-bg, #fff); border-color: var(--color-text-primary); }
-  .media-chip--book.is-active { background: var(--type-book); border-color: var(--type-book); color: #fff; }
-  .media-chip--movie.is-active { background: var(--type-movie); border-color: var(--type-movie); color: #fff; }
-  .media-chip--album.is-active { background: var(--type-album); border-color: var(--type-album); color: #fff; }
 
   .media-toggle {
     display: inline-flex;
-    border: 1px solid var(--color-border, rgba(128,128,128,0.3));
-    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    border-radius: 1em;
     overflow: hidden;
   }
   .media-view-btn {
     appearance: none; border: 0; background: transparent;
-    color: var(--color-text-tertiary); font: inherit; font-size: 0.82em;
-    padding: 0.3em 0.9em; cursor: pointer;
+    color: var(--color-text-tertiary); font: inherit; font-size: 0.78em;
+    padding: 0.3em 0.85em; cursor: pointer;
     transition: background 0.15s ease, color 0.15s ease;
   }
-  .media-view-btn.is-active { background: var(--color-accent, #555); color: #fff; }
-
-  /* Type badge — prominent, color-coded */
-  .media-type {
-    display: inline-block;
-    font-size: 0.66em;
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-caps);
-    font-weight: 700;
-    color: #fff;
-    background: var(--type-media);
-    border-radius: 4px;
-    padding: 0.18em 0.5em;
-    vertical-align: middle;
-  }
-  .media-type--book { background: var(--type-book); }
-  .media-type--movie { background: var(--type-movie); }
-  .media-type--album { background: var(--type-album); }
-  .media-type--show { background: var(--type-show); color: #3a2f00; }
+  .media-view-btn.is-active { background: var(--color-text-primary); color: var(--color-bg-primary); }
 
   .media-list, .media-grid { list-style: none; margin: 0; padding: 0; }
   #media-library.view-list .media-grid { display: none; }
@@ -159,7 +134,7 @@ Everything I've been reading, watching, and listening to — in one place.
   .media-row {
     display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5em 0.7em;
     padding: 0.6em 0;
-    border-bottom: 1px solid var(--color-border, rgba(128,128,128,0.12));
+    border-bottom: 1px solid var(--color-border);
   }
   .media-row-title {
     text-decoration: none; font-weight: var(--weight-medium);
@@ -167,7 +142,7 @@ Everything I've been reading, watching, and listening to — in one place.
   }
   .media-row-title:hover { text-decoration: underline; text-decoration-color: var(--color-accent); }
   .media-row-meta {
-    display: inline-flex; align-items: baseline; flex-wrap: wrap; gap: 0.7em;
+    display: inline-flex; align-items: baseline; flex-wrap: wrap; gap: 0.6em;
     font-size: 0.9em; color: var(--color-text-subtle);
   }
   .media-year { font-variant-numeric: tabular-nums; }
@@ -177,21 +152,24 @@ Everything I've been reading, watching, and listening to — in one place.
   .media-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-    gap: 1.4em 1.1em;
+    gap: 1.6em 1.1em;
   }
   .media-card a { display: block; text-decoration: none; color: var(--color-text-subtle); }
-  .media-cover-wrap { position: relative; display: block; }
   .media-cover {
     display: block; width: 100%; aspect-ratio: 2 / 3; object-fit: cover;
-    border-radius: 4px; background: var(--color-border, rgba(128,128,128,0.12));
-    box-shadow: 0 2px 8px rgba(0,0,0,0.18); transition: transform 0.15s ease;
+    border-radius: var(--border-radius, 4px); background: var(--color-bg-secondary);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.16); transition: transform 0.15s ease;
   }
   .media-card a:hover .media-cover { transform: translateY(-3px); }
-  .media-type--corner { position: absolute; top: 0.4em; left: 0.4em; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
-  .media-card-title {
-    display: block; margin-top: 0.5em; font-size: 0.82em;
-    line-height: var(--leading-snug, 1.3); color: var(--color-text-subtle);
+  .media-card-meta {
+    display: flex; align-items: baseline; justify-content: space-between; gap: 0.5em;
+    margin-top: 0.55em;
   }
+  .media-card-title {
+    font-size: 0.82em; line-height: var(--leading-snug, 1.3);
+    color: var(--color-text-subtle);
+  }
+  .media-card .tag { flex: none; }
 
   @media (max-width: 600px) {
     .media-grid { grid-template-columns: repeat(auto-fill, minmax(90px, 1fr)); }
@@ -203,7 +181,7 @@ Everything I've been reading, watching, and listening to — in one place.
     var lib = document.getElementById('media-library');
     if (!lib) return;
     var viewBtns = document.querySelectorAll('.media-view-btn');
-    var chips = document.querySelectorAll('.media-chip');
+    var chips = document.querySelectorAll('.media-filters .tag');
 
     function setView(view) {
       lib.classList.remove('view-list', 'view-covers');

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -7,12 +7,17 @@ permalink: /media/
 
 # Media Diet
 
-Everything I've been reading and watching, in one place.
+Everything I've been reading, watching, and listening to — in one place.
 
 {% assign entries = site.notes | where_exp: "n", "n.cover" | where_exp: "n", "n.path contains 'MediaDiet/'" | sort: "created" | reverse %}
 
 <div class="media-toolbar">
-  <span class="media-count">{{ entries | size }} entries</span>
+  <div class="media-filters" role="group" aria-label="Filter by type">
+    <button type="button" class="media-chip is-active" data-filter="all">All</button>
+    <button type="button" class="media-chip media-chip--book" data-filter="book">Books</button>
+    <button type="button" class="media-chip media-chip--movie" data-filter="movie">Movies</button>
+    <button type="button" class="media-chip media-chip--album" data-filter="album">Albums</button>
+  </div>
   <div class="media-toggle" role="group" aria-label="View mode">
     <button type="button" class="media-view-btn is-active" data-view="list">List</button>
     <button type="button" class="media-view-btn" data-view="covers">Covers</button>
@@ -26,20 +31,23 @@ Everything I've been reading and watching, in one place.
       {% assign type = 'Media' %}
       {% if e.path contains '/Books/' %}{% assign type = 'Book' %}
       {% elsif e.path contains '/Movies/' %}{% assign type = 'Movie' %}
+      {% elsif e.path contains '/Albums/' %}{% assign type = 'Album' %}
       {% elsif e.path contains '/Shows/' or e.path contains '/TV/' %}{% assign type = 'Show' %}
       {% endif %}
       {% if e.type %}{% assign type = e.type %}{% endif %}
       {% assign clean_title = e.title | replace: '📚 ', '' | replace: '🎬 ', '' | replace: '📺 ', '' | replace: '🦖 ', '' %}
       {% assign creator = '' %}
-      {% if e.author %}{% assign creator = e.author | join: ', ' | replace: '[[', '' | replace: ']]', '' %}
-      {% elsif e.director %}{% assign creator = e.director | join: ', ' | replace: '[[', '' | replace: ']]', '' %}{% endif %}
-      <li class="media-row">
+      {% if e.author %}{% assign creator = e.author | join: ', ' %}
+      {% elsif e.director %}{% assign creator = e.director | join: ', ' %}
+      {% elsif e.artist %}{% assign creator = e.artist | join: ', ' %}{% endif %}
+      {% assign creator = creator | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
+      <li class="media-row" data-type="{{ type | downcase }}">
         <a class="internal-link media-row-title" href="{{ site.baseurl }}{{ e.url }}">{{ clean_title }}</a>
         <span class="media-row-meta">
           <span class="media-type media-type--{{ type | downcase }}">{{ type }}</span>
           {% if creator != '' %}<span class="media-creator">{{ creator }}</span>{% endif %}
           {% if e.year %}<span class="media-year">{{ e.year }}</span>{% endif %}
-          {% if e.rating %}<span class="media-rating">Rated {{ e.rating }}</span>{% endif %}
+          {% if e.rating %}<span class="media-rating">★ {{ e.rating }}</span>{% endif %}
         </span>
       </li>
     {% endfor %}
@@ -47,10 +55,20 @@ Everything I've been reading and watching, in one place.
 
   <ul class="media-grid">
     {% for e in entries %}
+      {% assign type = 'Media' %}
+      {% if e.path contains '/Books/' %}{% assign type = 'Book' %}
+      {% elsif e.path contains '/Movies/' %}{% assign type = 'Movie' %}
+      {% elsif e.path contains '/Albums/' %}{% assign type = 'Album' %}
+      {% elsif e.path contains '/Shows/' or e.path contains '/TV/' %}{% assign type = 'Show' %}
+      {% endif %}
+      {% if e.type %}{% assign type = e.type %}{% endif %}
       {% assign clean_title = e.title | replace: '📚 ', '' | replace: '🎬 ', '' | replace: '📺 ', '' | replace: '🦖 ', '' %}
-      <li class="media-card">
+      <li class="media-card" data-type="{{ type | downcase }}">
         <a href="{{ site.baseurl }}{{ e.url }}" title="{{ clean_title }}">
-          <img class="media-cover" src="{{ e.cover }}" alt="Cover of {{ clean_title }}" loading="lazy" />
+          <span class="media-cover-wrap">
+            <img class="media-cover" src="{{ e.cover }}" alt="Cover of {{ clean_title }}" loading="lazy" />
+            <span class="media-type media-type--{{ type | downcase }} media-type--corner">{{ type }}</span>
+          </span>
           <span class="media-card-title">{{ clean_title }}</span>
         </a>
       </li>
@@ -62,21 +80,43 @@ Everything I've been reading and watching, in one place.
 <style>
   .wrapper { max-width: 46em; }
 
+  /* Per-type accent colors */
+  #media-library, .media-toolbar {
+    --type-book: #2a9d8f;
+    --type-movie: #e76f51;
+    --type-album: #6a67ce;
+    --type-show: #e9c46a;
+    --type-media: var(--color-text-tertiary);
+  }
+
   .media-toolbar {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.8em 1em;
     margin: 2em 0 1.4em;
-    gap: 1em;
   }
 
-  .media-count {
-    font-size: var(--text-caption);
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-caps);
+  .media-filters { display: inline-flex; flex-wrap: wrap; gap: 0.4em; }
+
+  .media-chip {
+    appearance: none;
+    border: 1px solid var(--color-border, rgba(128,128,128,0.3));
+    background: transparent;
     color: var(--color-text-tertiary);
-    font-weight: var(--weight-medium);
+    font: inherit;
+    font-size: 0.82em;
+    padding: 0.25em 0.75em;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
   }
+  .media-chip:hover { color: var(--color-text-primary); }
+  .media-chip.is-active { background: var(--color-text-primary); color: var(--color-bg, #fff); border-color: var(--color-text-primary); }
+  .media-chip--book.is-active { background: var(--type-book); border-color: var(--type-book); color: #fff; }
+  .media-chip--movie.is-active { background: var(--type-movie); border-color: var(--type-movie); color: #fff; }
+  .media-chip--album.is-active { background: var(--type-album); border-color: var(--type-album); color: #fff; }
 
   .media-toggle {
     display: inline-flex;
@@ -84,71 +124,54 @@ Everything I've been reading and watching, in one place.
     border-radius: 999px;
     overflow: hidden;
   }
-
   .media-view-btn {
-    appearance: none;
-    border: 0;
-    background: transparent;
-    color: var(--color-text-tertiary);
-    font: inherit;
-    font-size: var(--text-ui, 0.9em);
-    padding: 0.3em 0.9em;
-    cursor: pointer;
+    appearance: none; border: 0; background: transparent;
+    color: var(--color-text-tertiary); font: inherit; font-size: 0.82em;
+    padding: 0.3em 0.9em; cursor: pointer;
     transition: background 0.15s ease, color 0.15s ease;
   }
+  .media-view-btn.is-active { background: var(--color-accent, #555); color: #fff; }
 
-  .media-view-btn.is-active {
-    background: var(--color-accent, #555);
+  /* Type badge — prominent, color-coded */
+  .media-type {
+    display: inline-block;
+    font-size: 0.66em;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+    font-weight: 700;
     color: #fff;
+    background: var(--type-media);
+    border-radius: 4px;
+    padding: 0.18em 0.5em;
+    vertical-align: middle;
   }
+  .media-type--book { background: var(--type-book); }
+  .media-type--movie { background: var(--type-movie); }
+  .media-type--album { background: var(--type-album); }
+  .media-type--show { background: var(--type-show); color: #3a2f00; }
 
-  /* Toggle visibility driven by the container class */
   .media-list, .media-grid { list-style: none; margin: 0; padding: 0; }
-
   #media-library.view-list .media-grid { display: none; }
   #media-library.view-covers .media-list { display: none; }
+  .is-hidden { display: none !important; }
 
   /* ---- List view ---- */
   .media-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 0.5em 0.7em;
-    padding: 0.55em 0;
+    display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5em 0.7em;
+    padding: 0.6em 0;
     border-bottom: 1px solid var(--color-border, rgba(128,128,128,0.12));
   }
-
   .media-row-title {
-    text-decoration: none;
-    font-weight: var(--weight-medium);
+    text-decoration: none; font-weight: var(--weight-medium);
     color: var(--color-text-primary);
   }
-  .media-row-title:hover {
-    text-decoration: underline;
-    text-decoration-color: var(--color-accent);
-  }
-
+  .media-row-title:hover { text-decoration: underline; text-decoration-color: var(--color-accent); }
   .media-row-meta {
-    display: inline-flex;
-    align-items: baseline;
-    flex-wrap: wrap;
-    gap: 0.7em;
-    font-size: 0.9em;
-    color: var(--color-text-subtle);
+    display: inline-flex; align-items: baseline; flex-wrap: wrap; gap: 0.7em;
+    font-size: 0.9em; color: var(--color-text-subtle);
   }
-
-  .media-type {
-    font-size: 0.72em;
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-caps);
-    font-weight: var(--weight-medium);
-    color: var(--color-text-tertiary);
-    border: 1px solid var(--color-border, rgba(128,128,128,0.3));
-    border-radius: 4px;
-    padding: 0.05em 0.45em;
-  }
-
   .media-year { font-variant-numeric: tabular-nums; }
+  .media-rating { color: var(--color-text-tertiary); }
 
   /* ---- Covers view ---- */
   .media-grid {
@@ -156,31 +179,18 @@ Everything I've been reading and watching, in one place.
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     gap: 1.4em 1.1em;
   }
-
-  .media-card a {
-    display: block;
-    text-decoration: none;
-    color: var(--color-text-secondary, var(--color-text-tertiary));
-  }
-
+  .media-card a { display: block; text-decoration: none; color: var(--color-text-subtle); }
+  .media-cover-wrap { position: relative; display: block; }
   .media-cover {
-    display: block;
-    width: 100%;
-    aspect-ratio: 2 / 3;
-    object-fit: cover;
-    border-radius: 4px;
-    background: var(--color-border, rgba(128,128,128,0.12));
-    box-shadow: 0 2px 8px rgba(0,0,0,0.18);
-    transition: transform 0.15s ease;
+    display: block; width: 100%; aspect-ratio: 2 / 3; object-fit: cover;
+    border-radius: 4px; background: var(--color-border, rgba(128,128,128,0.12));
+    box-shadow: 0 2px 8px rgba(0,0,0,0.18); transition: transform 0.15s ease;
   }
   .media-card a:hover .media-cover { transform: translateY(-3px); }
-
+  .media-type--corner { position: absolute; top: 0.4em; left: 0.4em; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
   .media-card-title {
-    display: block;
-    margin-top: 0.5em;
-    font-size: 0.82em;
-    line-height: var(--leading-snug, 1.3);
-    color: var(--color-text-subtle);
+    display: block; margin-top: 0.5em; font-size: 0.82em;
+    line-height: var(--leading-snug, 1.3); color: var(--color-text-subtle);
   }
 
   @media (max-width: 600px) {
@@ -191,21 +201,26 @@ Everything I've been reading and watching, in one place.
 <script>
   (function () {
     var lib = document.getElementById('media-library');
-    var btns = document.querySelectorAll('.media-view-btn');
-    if (!lib || !btns.length) return;
+    if (!lib) return;
+    var viewBtns = document.querySelectorAll('.media-view-btn');
+    var chips = document.querySelectorAll('.media-chip');
 
     function setView(view) {
       lib.classList.remove('view-list', 'view-covers');
       lib.classList.add('view-' + view);
-      btns.forEach(function (b) {
-        b.classList.toggle('is-active', b.dataset.view === view);
-      });
+      viewBtns.forEach(function (b) { b.classList.toggle('is-active', b.dataset.view === view); });
       try { localStorage.setItem('mediaView', view); } catch (e) {}
     }
 
-    btns.forEach(function (b) {
-      b.addEventListener('click', function () { setView(b.dataset.view); });
-    });
+    function setFilter(type) {
+      lib.querySelectorAll('[data-type]').forEach(function (el) {
+        el.classList.toggle('is-hidden', type !== 'all' && el.dataset.type !== type);
+      });
+      chips.forEach(function (c) { c.classList.toggle('is-active', c.dataset.filter === type); });
+    }
+
+    viewBtns.forEach(function (b) { b.addEventListener('click', function () { setView(b.dataset.view); }); });
+    chips.forEach(function (c) { c.addEventListener('click', function () { setFilter(c.dataset.filter); }); });
 
     var saved;
     try { saved = localStorage.getItem('mediaView'); } catch (e) {}

--- a/_pages/travels.md
+++ b/_pages/travels.md
@@ -8,11 +8,24 @@ permalink: /travels/
 <p class="subtitle">{{ page.description }}</p>
 
 {% assign travel_notes = site.notes | where_exp: "item", "item.tags contains '#travel'" | sort: "year" | reverse %}
+
+<div class="index-toolbar">
+  <span class="sort-control">
+    <label for="travels-sort">Sort</label>
+    <select id="travels-sort" class="sort-select" data-sort-scope=".index-table" data-sort-item="tr">
+      <option value="date">Date</option>
+      <option value="az">A→Z</option>
+    </select>
+  </span>
+</div>
+
 <table class="index-table">
   {% for note in travel_notes %}
-  <tr>
+  <tr data-title="{{ note.title | downcase | escape }}" data-date="{{ note.year }}">
     <td class="index-title"><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></td>
     <td class="index-date muted">{{ note.year }}</td>
   </tr>
   {% endfor %}
 </table>
+
+<script src="{{ site.baseurl }}/assets/js/sortable.js"></script>

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -645,11 +645,16 @@ button.tag.is-active {
 
 /* Individual media note (Books / Movies / Albums) — a richer header
    built from frontmatter instead of the generic note layout. */
+.media-note-type {
+  display: inline-block;
+  margin: 0 0 0.9em;
+}
+
 .media-note-head {
   display: flex;
   gap: 1.5em;
   align-items: flex-start;
-  margin: 0.5em 0 1.6em;
+  margin: 0 0 1.6em;
 }
 
 .media-note-cover {
@@ -664,8 +669,6 @@ button.tag.is-active {
 .media-note-meta { min-width: 0; }
 
 .media-note-meta h1 { margin: 0 0 0.4em; }
-
-.media-note-type { margin: 0.1em 0 1em; }
 
 .media-facts {
   display: grid;

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -645,20 +645,25 @@ button.tag.is-active {
 
 /* Individual media note (Books / Movies / Albums) — a richer header
    built from frontmatter instead of the generic note layout. */
-.media-note-type {
-  display: inline-block;
-  margin: 0 0 0.9em;
-}
-
+/* Grid so the tag is an eyebrow above the title, while the cover's top
+   aligns with the title row (not with the eyebrow). */
 .media-note-head {
-  display: flex;
-  gap: 1.5em;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 1.5em;
   margin: 0 0 1.6em;
 }
 
+.media-note-type {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: start;
+  margin: 0 0 0.5em;
+}
+
 .media-note-cover {
-  flex: none;
+  grid-column: 1;
+  grid-row: 2;
   width: 150px;
   height: auto;
   border-radius: var(--border-radius, 4px);
@@ -666,7 +671,11 @@ button.tag.is-active {
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
 }
 
-.media-note-meta { min-width: 0; }
+.media-note-meta {
+  grid-column: 2;
+  grid-row: 2;
+  min-width: 0;
+}
 
 .media-note-meta h1 { margin: 0 0 0.4em; }
 
@@ -699,8 +708,9 @@ button.tag.is-active {
 }
 
 @media (max-width: 600px) {
-  .media-note-head { flex-direction: column; gap: 1.1em; }
-  .media-note-cover { width: 130px; }
+  .media-note-head { grid-template-columns: 1fr; row-gap: 0.4em; }
+  .media-note-type, .media-note-cover, .media-note-meta { grid-column: 1; grid-row: auto; }
+  .media-note-cover { width: 130px; margin-bottom: 0.7em; }
 }
 
 .fade-in-section {

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -652,17 +652,9 @@ button.tag.is-active {
   margin: 0.5em 0 1.6em;
 }
 
-.media-note-cover-col {
+.media-note-cover {
   flex: none;
   width: 150px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.7em;
-}
-
-.media-note-cover {
-  width: 100%;
   height: auto;
   border-radius: var(--border-radius, 4px);
   background: var(--color-bg-secondary);
@@ -671,7 +663,9 @@ button.tag.is-active {
 
 .media-note-meta { min-width: 0; }
 
-.media-note-meta h1 { margin: 0 0 0.5em; }
+.media-note-meta h1 { margin: 0 0 0.4em; }
+
+.media-note-type { margin: 0.1em 0 1em; }
 
 .media-facts {
   display: grid;
@@ -703,7 +697,7 @@ button.tag.is-active {
 
 @media (max-width: 600px) {
   .media-note-head { flex-direction: column; gap: 1.1em; }
-  .media-note-cover-col { width: 130px; }
+  .media-note-cover { width: 130px; }
 }
 
 .fade-in-section {

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -636,6 +636,68 @@ button.tag.is-active {
   border-color: var(--color-text-primary);
 }
 
+/* Filled/empty rating marks (7-point), used on /media/ and media notes */
+.rating-marks {
+  letter-spacing: 0.12em;
+  white-space: nowrap;
+  font-size: 0.92em;
+}
+
+/* Individual media note (Books / Movies / Albums) — a richer header
+   built from frontmatter instead of the generic note layout. */
+.media-note-head {
+  display: flex;
+  gap: 1.5em;
+  align-items: flex-start;
+  margin: 0.5em 0 1.6em;
+}
+
+.media-note-cover {
+  width: 150px;
+  flex: none;
+  height: auto;
+  border-radius: var(--border-radius, 4px);
+  background: var(--color-bg-secondary);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+}
+
+.media-note-meta { min-width: 0; }
+
+.media-note-meta h1 { margin: 0.35em 0 0.5em; }
+
+.media-facts {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35em 1.1em;
+  margin: 0;
+  font-size: var(--text-ui);
+}
+
+.media-facts dt {
+  color: var(--color-text-tertiary);
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+}
+
+.media-facts dd { margin: 0; color: var(--color-text-secondary); }
+
+.media-note-plot {
+  color: var(--color-text-tertiary);
+  font-style: italic;
+  max-width: 35em;
+  margin: 0 0 1.6em;
+}
+
+.media-note-back {
+  margin-top: 2.5em;
+  font-size: var(--text-ui);
+}
+
+@media (max-width: 600px) {
+  .media-note-head { flex-direction: column; gap: 1.1em; }
+  .media-note-cover { width: 130px; }
+}
+
 .fade-in-section {
   opacity: 0;
   transform: translateY(20px);

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -603,6 +603,33 @@ table {
   }
 }
 
+/* Sort control for index views (shared) */
+.index-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin: 1.4em 0 0;
+}
+
+.sort-control {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5em;
+  font-size: 0.85em;
+  color: var(--color-text-tertiary);
+}
+
+.sort-select {
+  font: inherit;
+  font-size: 0.92em;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 1em;
+  padding: 0.25em 0.7em;
+  cursor: pointer;
+}
+
 /* Slash Packaging–style tag: a minimal outlined pill, muted and
    monochrome, built on the site's tokens. Shared across index/grid
    views (media, concerts, travels). Works as <span>, <a>, or <button>. */

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -652,9 +652,17 @@ button.tag.is-active {
   margin: 0.5em 0 1.6em;
 }
 
-.media-note-cover {
-  width: 150px;
+.media-note-cover-col {
   flex: none;
+  width: 150px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.7em;
+}
+
+.media-note-cover {
+  width: 100%;
   height: auto;
   border-radius: var(--border-radius, 4px);
   background: var(--color-bg-secondary);
@@ -663,7 +671,7 @@ button.tag.is-active {
 
 .media-note-meta { min-width: 0; }
 
-.media-note-meta h1 { margin: 0.35em 0 0.5em; }
+.media-note-meta h1 { margin: 0 0 0.5em; }
 
 .media-facts {
   display: grid;
@@ -695,7 +703,7 @@ button.tag.is-active {
 
 @media (max-width: 600px) {
   .media-note-head { flex-direction: column; gap: 1.1em; }
-  .media-note-cover { width: 130px; }
+  .media-note-cover-col { width: 130px; }
 }
 
 .fade-in-section {

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -575,21 +575,65 @@ table {
     line-height: var(--leading-prose);
   }
 
-  // Reset the generic table column widths above for this 2-column layout.
-  td:nth-child(1) { width: auto; }
-  td:nth-child(2) { width: 1%; }
-
+  // Class-based widths so the same table works with 2 columns
+  // (title · date, e.g. /travels/) or 3 (title · meta · date, e.g.
+  // /concerts/): the title greedily takes the row, the rest shrink.
   .index-title {
+    width: 100%;
     font-weight: var(--weight-medium);
   }
 
+  .index-meta {
+    white-space: nowrap;
+    padding-left: 1.5em;
+    font-size: var(--text-ui);
+  }
+
   .index-date {
+    width: 1%;
     text-align: right;
     white-space: nowrap;
     padding-left: 1.5em;
     font-size: var(--text-ui);
     font-variant-numeric: tabular-nums;
   }
+
+  @media (max-width: 600px) {
+    .index-meta { display: none; }
+  }
+}
+
+/* Slash Packaging–style tag: a minimal outlined pill, muted and
+   monochrome, built on the site's tokens. Shared across index/grid
+   views (media, concerts, travels). Works as <span>, <a>, or <button>. */
+.tag {
+  display: inline-block;
+  border: 1px solid var(--color-border);
+  padding: 0.1em 0.55em 0.15em;
+  border-radius: 1em;
+  font-size: 0.75em;
+  line-height: 1.5;
+  color: var(--color-text-tertiary);
+  background: transparent;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+a.tag:hover,
+button.tag:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-tertiary);
+}
+
+button.tag {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+button.tag.is-active {
+  color: var(--color-bg-primary);
+  background: var(--color-text-primary);
+  border-color: var(--color-text-primary);
 }
 
 .fade-in-section {

--- a/assets/js/sortable.js
+++ b/assets/js/sortable.js
@@ -1,0 +1,36 @@
+// Reusable client-side sort for index views (media, concerts, travels).
+// A <select class="sort-select"> drives one or more containers:
+//   data-sort-scope : CSS selector matching the container(s) to reorder
+//   data-sort-item  : selector for the sortable items within each container
+// Items expose data-title / data-date / data-rating for the sort keys.
+(function () {
+  function compare(key) {
+    return function (a, b) {
+      if (key === 'az') {
+        return (a.getAttribute('data-title') || '').localeCompare(b.getAttribute('data-title') || '');
+      }
+      if (key === 'rating') {
+        return (parseFloat(b.getAttribute('data-rating')) || 0) - (parseFloat(a.getAttribute('data-rating')) || 0);
+      }
+      // 'date' — newest first
+      return (b.getAttribute('data-date') || '').localeCompare(a.getAttribute('data-date') || '');
+    };
+  }
+
+  function wire(sel) {
+    function apply() {
+      var key = sel.value;
+      var containers = document.querySelectorAll(sel.getAttribute('data-sort-scope'));
+      Array.prototype.forEach.call(containers, function (container) {
+        var items = Array.prototype.slice.call(container.querySelectorAll(sel.getAttribute('data-sort-item')));
+        if (!items.length) return;
+        items.sort(compare(key));
+        var parent = items[0].parentNode;
+        items.forEach(function (it) { parent.appendChild(it); });
+      });
+    }
+    sel.addEventListener('change', apply);
+  }
+
+  Array.prototype.forEach.call(document.querySelectorAll('.sort-select'), wire);
+})();


### PR DESCRIPTION
## Summary

Replaces the section-based `/media/` index with a single **merged library** of all media entries, driven by the `cover` frontmatter field, with a **List / Covers toggle**.

- **List view** — title, type badge, creator, year, rating
- **Covers view** — responsive cover-art grid (2:3 posters) from the `cover` yaml
- Toggle is vanilla JS, persisted via `localStorage`
- Renders any note under `MediaDiet/` that has a `cover` field, so future movie/show entries appear automatically once they follow the same schema the books use (`type`, `cover`, `rating`, `year`, `author`)

## Scope notes
- Shows the 3 existing book entries today (the only entry-shaped media with covers). Movies/shows are still editorial tables and will populate once converted to individual entries.
- The editorial notes (`Coop's 100 movies`, `2024 Media Diet`, `2025 Reading List`) are **retained in the repo** — just no longer linked from the homepage or media page.

## Verification
A local Jekyll build can't run in the authoring environment (the git-sourced `jekyll-last-modified-at` gem is blocked by the egress policy). Use the **Netlify deploy preview** on this PR to click the List/Covers toggle and confirm the cover grid renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4eYfmBRWXgKJdC1U1ZLTR)_