### PR TITLE
Fix highlights page white cards in dark mode

### DIFF
--- a/_pages/highlights.html
+++ b/_pages/highlights.html
@@ -53,7 +53,7 @@ async function loadHighlights(pageUrl = null, append = false) {
     
     highlights.forEach(h => {
       const item = document.createElement('div');
-      item.className = 'highlight';
+      item.className = 'book-highlight';
       
       // Build comprehensive attribution
       let attribution = '';

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -775,7 +775,7 @@ button.tag.is-active {
 
 /* Highlights page styling */
 #highlights {
-  .highlight {
+  .book-highlight {
     margin-bottom: 2em;
 
     blockquote {


### PR DESCRIPTION
## Problem

`https://coopersmith.nyc/highlights` rendered each highlight as a big white, unreadable card in dark mode.

## Cause

The highlights page created each entry as `<div class="highlight">`. But `.highlight` is also **Rouge's class for code syntax-highlighting blocks**, defined in `_sass/_code.scss` as `background: #f8f8f8; border-radius: 3px` — a hardcoded near-white background with no dark-mode variant. The Readwise highlights inherited that background, so in dark mode every entry became a near-white card with faint, unreadable text.

## Fix

Rename the highlights-page class from `highlight` to `book-highlight` so it no longer collides with Rouge:

- `_pages/highlights.html` — `item.className = 'book-highlight'`
- `_sass/_style.scss` — `#highlights .highlight` → `#highlights .book-highlight`

Highlights now inherit the site's CSS-variable-based `blockquote` styling, which adapts to light/dark correctly.

## Verification

Compiled the full stylesheet (the collision only appears once `_code.scss` is included) and rendered the page in a headless browser:

- **Dark mode:** readable light text on the dark background, no white cards.
- **Light mode:** unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrvmNBNpK1xoViRkQuVgdS)_