### PR TITLE
Add human-readable changelog generated from merged PRs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,15 @@ description: Cooper Smith's digital garden
 url: "https://coopersmith.nyc"  # Your production URL
 author:
   name: Cooper Smith
+
+# Typeface — single source of truth for the font. Drives the Google Fonts
+# load (_includes/head.html), the --font-sans token (styles.scss), and the
+# colophon label, so they can never drift apart.
+font:
+  name: Hanken Grotesk
+  weights: "400;500;600;700"
+  specimen: https://fonts.google.com/specimen/Hanken+Grotesk
+
 include:             ['_pages']
 exclude:             ['_includes/notes_graph.json']
 # You may need to change the base URL depending on your deploy configuration.

--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,0 +1,202 @@
+# Changelog entries, generated from merged pull requests by
+# scripts/generate_changelog.rb (each summary is a human-readable "what & why"
+# written by Claude). This file is committed so the site build never calls any
+# API. You can hand-edit any summary/title/category — the generator only adds
+# NEW merged PRs and leaves existing entries untouched.
+#
+# Fields: number, date (YYYY-MM-DD), title, category, summary, url
+# Categories: feature, fix, design, refactor, content, chore, polish
+---
+- number: 38
+  date: '2026-06-30'
+  title: Redesign the Media Diet as a merged library
+  category: feature
+  summary: >-
+    Rebuilt the Media Diet into a single library of everything I've read and
+    watched, with a List/Covers toggle that remembers your choice — the goal
+    was one home for all media that auto-includes any note with a cover image.
+  url: https://github.com/coopersmith/cooper-site/pull/38
+
+- number: 37
+  date: '2026-06-28'
+  title: Make the Travels page post-driven
+  category: refactor
+  summary: >-
+    Replaced a 230-line hand-maintained travels list with a dynamic index built
+    from notes tagged #travel, so adding a trip is now just writing a note —
+    matching the pattern the Concerts page already used.
+  url: https://github.com/coopersmith/cooper-site/pull/37
+
+- number: 36
+  date: '2026-06-28'
+  title: Refresh homepage links and add a Media Diet index
+  category: content
+  summary: >-
+    Tidied the homepage "Elsewhere" links (Photos became "Visual Diary") and
+    introduced a dedicated /media index, giving what I'm reading and watching a
+    proper front door.
+  url: https://github.com/coopersmith/cooper-site/pull/36
+
+- number: 35
+  date: '2026-06-28'
+  title: Reverse-geocode check-in neighborhoods
+  category: feature
+  summary: >-
+    Foursquare's neighborhood tags turned out to be sparse, so the check-in line
+    now fills the gaps by reverse-geocoding each spot's coordinates through
+    OpenStreetMap — all server-side and edge-cached, so it never slows the page.
+  url: https://github.com/coopersmith/cooper-site/pull/35
+
+- number: 34
+  date: '2026-06-28'
+  title: Show neighborhood alongside city in the last check-in
+  category: feature
+  summary: >-
+    Enriched the "last seen at" line to include the neighborhood when Foursquare
+    has one, so it reads "Greenwich Village, New York" — falling back to just the
+    city when it doesn't.
+  url: https://github.com/coopersmith/cooper-site/pull/34
+
+- number: 33
+  date: '2026-06-28'
+  title: Show the now-playing track inline
+  category: polish
+  summary: >-
+    Small fix to the homepage "Lately" line so the currently-playing track reads
+    as a second sentence in the same paragraph instead of dropping onto its own
+    line.
+  url: https://github.com/coopersmith/cooper-site/pull/33
+
+- number: 32
+  date: '2026-06-28'
+  title: Turn on the Foursquare last check-in
+  category: feature
+  summary: >-
+    Got the long-broken "last check-in" module working by switching to a user
+    OAuth token — the old client-credentials auth could never read personal
+    check-ins, which is why it had sat commented out.
+  url: https://github.com/coopersmith/cooper-site/pull/32
+
+- number: 31
+  date: '2026-06-28'
+  title: Add a "See more" link and drop the top nav
+  category: design
+  summary: >-
+    Added a "See more →" link under the recent notes and removed the top-level
+    navigation entirely, betting that the page itself is a better way to explore
+    the site than a menu bar.
+  url: https://github.com/coopersmith/cooper-site/pull/31
+
+- number: 30
+  date: '2026-06-28'
+  title: Redesign the home page as a scannable index
+  category: design
+  summary: >-
+    Reworked the home page from a wall of bio prose into a scannable index — a
+    tight two-line intro, a labeled recent-notes list, and an "Elsewhere"
+    directory — inspired by personal sites like jmduke.com and stephango.com.
+  url: https://github.com/coopersmith/cooper-site/pull/30
+
+- number: 29
+  date: '2026-06-20'
+  title: Track note creation dates
+  category: feature
+  summary: >-
+    Started recording when each note was first written — from frontmatter or its
+    first git commit — so the homepage and index can sort by creation date
+    rather than last edit, which better reflects when I actually made something.
+  url: https://github.com/coopersmith/cooper-site/pull/29
+
+- number: 28
+  date: '2026-06-17'
+  title: Move typography and color to design tokens
+  category: refactor
+  summary: >-
+    Migrated the stylesheet from scattered SCSS variables to a CSS
+    custom-property token system for type, color, and spacing, establishing a
+    single source of truth that makes future restyles far easier.
+  url: https://github.com/coopersmith/cooper-site/pull/28
+
+- number: 27
+  date: '2026-06-13'
+  title: Fix the real mobile page overflow
+  category: fix
+  summary: >-
+    Traced the actual mobile bug — the whole page rendered wider than the screen
+    — to a grid column with no width cap, and fixed it with minmax(0, 1fr) so
+    lines finally stop clipping off the right edge.
+  url: https://github.com/coopersmith/cooper-site/pull/27
+
+- number: 26
+  date: '2026-06-13'
+  title: First pass at mobile text overflow
+  category: fix
+  summary: >-
+    Added word-wrapping rules so long wikilinks and URLs stop pushing text past
+    the viewport, and bumped mobile body text to 17px for readability — a first
+    attempt that #27 later completed.
+  url: https://github.com/coopersmith/cooper-site/pull/26
+
+- number: 14
+  date: '2025-08-29'
+  title: Fix light/dark mode accessibility
+  category: fix
+  summary: >-
+    Improved accessibility in both color modes — raised low-contrast hover
+    colors, added skip links for keyboard users, and honored
+    prefers-reduced-motion so animations respect that setting.
+  url: https://github.com/coopersmith/cooper-site/pull/14
+
+- number: 12
+  date: '2025-08-29'
+  title: Another pass at typography
+  category: design
+  summary: >-
+    Refined the site's type styles for clearer hierarchy and better readability,
+    taking cues from a few reference sites I admire.
+  url: https://github.com/coopersmith/cooper-site/pull/12
+
+- number: 11
+  date: '2025-08-29'
+  title: Add attribution to highlights
+  category: content
+  summary: >-
+    Added source attribution to the quotes on the highlights page so each one
+    credits the book or article it came from.
+  url: https://github.com/coopersmith/cooper-site/pull/11
+
+- number: 10
+  date: '2025-08-13'
+  title: Add a Readwise highlights page
+  category: feature
+  summary: >-
+    Built a /highlights page that pulls my recent Readwise highlights, backed by
+    a Netlify function that proxies the Readwise API so the access token stays
+    server-side.
+  url: https://github.com/coopersmith/cooper-site/pull/10
+
+- number: 7
+  date: '2025-08-06'
+  title: Add a scrapbook gallery with lightbox
+  category: feature
+  summary: >-
+    Created a /scrapbook page that builds a responsive photo grid from images in
+    assets/scrapbook, with a SimpleLightbox click-to-zoom view.
+  url: https://github.com/coopersmith/cooper-site/pull/7
+
+- number: 6
+  date: '2025-08-06'
+  title: Document and ignore scrapbook assets
+  category: chore
+  summary: >-
+    Documented the scrapbook image folder with a README and told git to ignore
+    the images, keeping personal photos local instead of committed to the repo.
+  url: https://github.com/coopersmith/cooper-site/pull/6
+
+- number: 4
+  date: '2025-08-05'
+  title: Fix a spelling typo in Travels
+  category: fix
+  summary: >-
+    Corrected the spelling of Guerneville in the 2023 travels entry.
+  url: https://github.com/coopersmith/cooper-site/pull/4

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,1 +1,1 @@
-© 2025 <a class="internal-link" href="{{ site.baseurl }}/about">Cooper Smith</a>.
+© 2025 <a class="internal-link" href="{{ site.baseurl }}/about">Cooper Smith</a>. <a class="internal-link" href="{{ site.baseurl }}/colophon">Colophon</a> · <a class="internal-link" href="{{ site.baseurl }}/changelog/">Changelog</a>.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family={{ site.font.name | replace: ' ', '+' }}:wght@{{ site.font.weights }}&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="{{ site.baseurl }}/styles.css">
 

--- a/_pages/changelog.md
+++ b/_pages/changelog.md
@@ -1,0 +1,116 @@
+---
+title: Changelog
+description: A running, human-readable log of what I've been building on this site.
+permalink: /changelog/
+---
+
+<h1>Changelog</h1>
+<p class="subtitle">A running, human-readable log of what I've been building on this site — written up from each merged pull request.</p>
+
+{% comment %}
+  _data/changelog.yml is maintained newest-first (by date, then PR number) by
+  scripts/generate_changelog.rb, so we group in file order rather than re-sorting.
+  group_by_exp keeps first-appearance order, giving newest months first.
+{% endcomment %}
+{% assign groups = site.data.changelog | group_by_exp: "e", "e.date | date: '%B %Y'" %}
+
+<div class="changelog">
+  {% for group in groups %}
+    <section class="cl-group">
+      <p class="cl-month">{{ group.name }}</p>
+      <ul class="cl-list">
+        {% for e in group.items %}
+          <li class="cl-entry">
+            <div class="cl-line">
+              <span class="cl-date">{{ e.date | date: "%b %-d" }}</span>
+              <span class="cl-body">
+                <span class="cl-title">{{ e.title }}</span>
+                {% if e.category %}<span class="cl-tag cl-tag--{{ e.category }}">{{ e.category }}</span>{% endif %}
+                <span class="cl-summary">{{ e.summary }}</span>
+                {% if e.url %}<a class="cl-link" href="{{ e.url }}">#{{ e.number }} ↗</a>{% endif %}
+              </span>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endfor %}
+</div>
+
+<style>
+  .wrapper { max-width: 46em; }
+
+  .changelog { margin-top: 2.5em; }
+
+  .cl-group { margin-top: 2.6em; }
+  .cl-group:first-child { margin-top: 1.6em; }
+
+  .cl-month {
+    font-size: var(--text-caption);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+    color: var(--color-text-tertiary);
+    font-weight: var(--weight-medium);
+    margin: 0 0 1.1em;
+    padding-bottom: 0.5em;
+    border-bottom: 0.25px solid var(--color-border);
+  }
+
+  .cl-list { list-style: none; margin: 0; padding: 0; }
+  .cl-entry + .cl-entry { margin-top: 1.5em; }
+
+  .cl-line { display: flex; gap: 1em; align-items: baseline; }
+
+  .cl-date {
+    flex: 0 0 auto;
+    min-width: 3.6em;
+    color: var(--color-text-tertiary);
+    font-size: 0.9em;
+    font-variant-numeric: tabular-nums;
+    padding-top: 0.05em;
+  }
+
+  .cl-body { flex: 1 1 auto; min-width: 0; }
+
+  .cl-title {
+    font-weight: var(--weight-semibold);
+    color: var(--color-text-primary);
+  }
+
+  .cl-summary {
+    display: block;
+    margin-top: 0.3em;
+    color: var(--color-text-secondary);
+    line-height: var(--leading-relaxed);
+  }
+
+  .cl-tag {
+    display: inline-block;
+    margin-left: 0.5em;
+    padding: 0.08em 0.5em;
+    border-radius: 999px;
+    font-size: 0.68em;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+    font-weight: var(--weight-medium);
+    vertical-align: 0.12em;
+    color: var(--color-text-tertiary);
+    background: var(--color-bg-secondary);
+    border: 0.5px solid var(--color-border);
+  }
+
+  .cl-link {
+    display: inline-block;
+    margin-top: 0.35em;
+    font-size: 0.82em;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-tertiary);
+    text-decoration: none;
+  }
+  .cl-link:hover { color: var(--color-text-primary); }
+
+  @media (max-width: 600px) {
+    .cl-line { display: block; }
+    .cl-date { display: block; min-width: 0; margin-bottom: 0.25em; }
+  }
+</style>

--- a/_pages/colophon.md
+++ b/_pages/colophon.md
@@ -10,6 +10,8 @@ I'm not quite sure what this website is, but the closest notion is that of a dig
 
 This site is built with [Jekyll](https://jekyllrb.com/) and hosted on [Netlify](https://www.netlify.com/). Its written in [Markdown](https://www.markdownguide.org/) in [Obsidian](https://obsidian.md/) and [Cursor](https://www.cursor.com/) and started from the [aaaaaa](https://mmistakes.github.io/minimal-mistakes/) theme.
 
+If you're curious how it changes over time, there's a [changelog](/changelog/) — a plain-English log of what I've been tinkering with here, written up from the site's own commit history.
+
 Unless otherwise noted, all images are captured by me, often with a Leica camera including the [M10](https://www.leica-camera.com/en/product/m10-rangefinder-camera), [Q3](https://www.leica-camera.com/en/product/q3-compact-mirrorless-camera), and [M7](https://www.leica-camera.com/en/product/m7-rangefinder-camera). Film photos are either taken on a Leica M7, Mamiya 7II, or Contax T2, and are almost always shot on Kodak film, usually Portra 400.
 
 The font is [Inter](https://fonts.google.com/specimen/Inter) because of course. 

--- a/_pages/colophon.md
+++ b/_pages/colophon.md
@@ -6,15 +6,15 @@ permalink: /colophon
 
 # Colophon
 
-I'm not quite sure what this website is, but the closest notion is that of a digital garden. But more importantly for me, its a [home cooked meal](https://www.robinsloan.com/notes/home-cooked-app/?__readwiseLocation=). Perhaps its also [a complex search query to find fascinating people and make them route interesting stuff to your inbox](https://www.henrikkarlsson.xyz/p/search-query?utm_source=substack&utm_medium=email)
+I'm not quite sure what this website is, but the closest notion is that of a digital garden. But more importantly for me, it's a [home cooked meal](https://www.robinsloan.com/notes/home-cooked-app/?__readwiseLocation=). Perhaps it's also [a complex search query to find fascinating people and make them route interesting stuff to your inbox](https://www.henrikkarlsson.xyz/p/search-query?utm_source=substack&utm_medium=email)
 
-This site is built with [Jekyll](https://jekyllrb.com/) and hosted on [Netlify](https://www.netlify.com/). Its written in [Markdown](https://www.markdownguide.org/) in [Obsidian](https://obsidian.md/) and [Cursor](https://www.cursor.com/) and started from the [aaaaaa](https://mmistakes.github.io/minimal-mistakes/) theme.
+This site is built with [Jekyll](https://jekyllrb.com/) and hosted on [Netlify](https://www.netlify.com/). It's written in [Markdown](https://www.markdownguide.org/) in [Obsidian](https://obsidian.md/), and built and designed in partnership with my buddy [Claude](https://claude.ai). It started from the [aaaaaa](https://mmistakes.github.io/minimal-mistakes/) theme.
 
 If you're curious how it changes over time, there's a [changelog](/changelog/) — a plain-English log of what I've been tinkering with here, written up from the site's own commit history.
 
 Unless otherwise noted, all images are captured by me, often with a Leica camera including the [M10](https://www.leica-camera.com/en/product/m10-rangefinder-camera), [Q3](https://www.leica-camera.com/en/product/q3-compact-mirrorless-camera), and [M7](https://www.leica-camera.com/en/product/m7-rangefinder-camera). Film photos are either taken on a Leica M7, Mamiya 7II, or Contax T2, and are almost always shot on Kodak film, usually Portra 400.
 
-The font is [Inter](https://fonts.google.com/specimen/Inter) because of course. 
+The font is [{{ site.font.name }}]({{ site.font.specimen }}) because of course. 
 
 
 File over app.  

--- a/_pages/colophon.md
+++ b/_pages/colophon.md
@@ -8,13 +8,10 @@ permalink: /colophon
 
 I'm not quite sure what this website is, but the closest notion is that of a digital garden. But more importantly for me, it's a [home cooked meal](https://www.robinsloan.com/notes/home-cooked-app/?__readwiseLocation=). Perhaps it's also [a complex search query to find fascinating people and make them route interesting stuff to your inbox](https://www.henrikkarlsson.xyz/p/search-query?utm_source=substack&utm_medium=email)
 
-This site is built with [Jekyll](https://jekyllrb.com/) and hosted on [Netlify](https://www.netlify.com/). It's written in [Markdown](https://www.markdownguide.org/) in [Obsidian](https://obsidian.md/), and built and designed in partnership with my buddy [Claude](https://claude.ai). It started from the [aaaaaa](https://mmistakes.github.io/minimal-mistakes/) theme.
+Set in [{{ site.font.name }}]({{ site.font.specimen }}). This site is built with [Jekyll](https://jekyllrb.com/) and hosted on [Netlify](https://www.netlify.com/). It's written in [Markdown](https://www.markdownguide.org/) in [Obsidian](https://obsidian.md/), and built and designed in partnership with my buddy [Claude](https://claude.ai). It started from the [aaaaaa](https://mmistakes.github.io/minimal-mistakes/) theme.
 
 If you're curious how it changes over time, there's a [changelog](/changelog/) — a plain-English log of what I've been tinkering with here, written up from the site's own commit history.
 
 Unless otherwise noted, all images are captured by me, often with a Leica camera including the [M10](https://www.leica-camera.com/en/product/m10-rangefinder-camera), [Q3](https://www.leica-camera.com/en/product/q3-compact-mirrorless-camera), and [M7](https://www.leica-camera.com/en/product/m7-rangefinder-camera). Film photos are either taken on a Leica M7, Mamiya 7II, or Contax T2, and are almost always shot on Kodak film, usually Portra 400.
-
-The font is [{{ site.font.name }}]({{ site.font.specimen }}) because of course. 
-
 
 File over app.  

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -41,6 +41,7 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
     <li><a href="{{ site.baseurl }}/travels/">Travels</a> <span class="desc">— adventures around the world.</span></li>
     <li><a href="{{ site.baseurl }}/photos/">Visual Diary</a> <span class="desc">— my life through my lens.</span></li>
     <li><a href="{{ site.baseurl }}/media/">Media Diet</a> <span class="desc">— what I'm reading, watching, and listening to.</span></li>
+    <li><a href="{{ site.baseurl }}/changelog/">Changelog</a> <span class="desc">— what I've been building here, lately.</span></li>
     <li><a href="{{ site.baseurl }}/about">About</a> <span class="desc">— the longer version, and where to find me.</span></li>
   </ul>
 </section>

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -5,12 +5,16 @@
 // Shared SCSS values (consumed by other partials, e.g. _photos.scss)
 $border-radius: 8px;
 
+// Fallback if compiled outside styles.scss; styles.scss injects the real
+// value from _config.yml (site.font.name).
+$font-name: 'Hanken Grotesk' !default;
+
 :root {
   // ── Typography tokens ──────────────────────────────────────────────
-  // Single source of truth for the type system. Hanken Grotesk is loaded
-  // in _includes/head.html at weights 400 / 500 / 600 / 700 and used for
-  // both body and headings — a clean, neutral grotesk.
-  --font-sans: 'Hanken Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica', 'Arial', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  // The font name is set once in _config.yml and flows to the Google Fonts
+  // load (_includes/head.html), this token, and the colophon label. It is
+  // loaded at weights 400 / 500 / 600 / 700 and used for body and headings.
+  --font-sans: '#{$font-name}', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica', 'Arial', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 
   // Type scale
   --text-caption: 14px; // h5/h6 eyebrow labels

--- a/scripts/generate_changelog.rb
+++ b/scripts/generate_changelog.rb
@@ -1,0 +1,237 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# generate_changelog.rb
+# ---------------------------------------------------------------------------
+# Builds _data/changelog.yml from the repository's merged pull requests, using
+# Claude to turn each PR into a short, human-readable "what & why" sentence.
+#
+# It is INCREMENTAL: PRs already present in _data/changelog.yml are left
+# untouched, so re-running only summarizes newly-merged PRs (and preserves any
+# summaries you've hand-edited). The generated file is committed to the repo,
+# so the Jekyll/Netlify build itself never calls any API and stays deterministic.
+#
+# Usage:
+#   export ANTHROPIC_API_KEY=sk-ant-...   # required (summaries)
+#   export GITHUB_TOKEN=ghp_...           # optional (raises API rate limits)
+#   ruby scripts/generate_changelog.rb
+#
+# Environment options:
+#   CHANGELOG_REPO    owner/name to read PRs from   (default coopersmith/cooper-site)
+#   CHANGELOG_MODEL   Claude model for summaries     (default claude-sonnet-5)
+#   CHANGELOG_FORCE   set to "1" to re-summarize every PR, ignoring existing entries
+#   CHANGELOG_LIMIT   only process the N most recent new PRs (default: all)
+#
+# Uses only the Ruby standard library — no extra gems required.
+# ---------------------------------------------------------------------------
+
+require 'net/http'
+require 'json'
+require 'uri'
+require 'yaml'
+require 'time'
+require 'set'
+
+REPO       = ENV.fetch('CHANGELOG_REPO', 'coopersmith/cooper-site')
+MODEL      = ENV.fetch('CHANGELOG_MODEL', 'claude-sonnet-5')
+FORCE      = ENV['CHANGELOG_FORCE'] == '1'
+LIMIT      = ENV['CHANGELOG_LIMIT']&.to_i
+DATA_PATH  = File.expand_path('../_data/changelog.yml', __dir__)
+CATEGORIES = %w[feature fix design refactor content chore polish].freeze
+
+GH_TOKEN   = ENV['GITHUB_TOKEN']
+AI_KEY     = ENV['ANTHROPIC_API_KEY']
+
+# --- tiny HTTP helpers -----------------------------------------------------
+
+def gh_get(path, query = {})
+  uri = URI("https://api.github.com#{path}")
+  uri.query = URI.encode_www_form(query) unless query.empty?
+  req = Net::HTTP::Get.new(uri)
+  req['Accept'] = 'application/vnd.github+json'
+  req['User-Agent'] = 'cooper-site-changelog'
+  req['Authorization'] = "Bearer #{GH_TOKEN}" if GH_TOKEN && !GH_TOKEN.empty?
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+  unless res.is_a?(Net::HTTPSuccess)
+    abort "GitHub API #{res.code} for #{path}: #{res.body.to_s[0, 200]}"
+  end
+  JSON.parse(res.body)
+end
+
+def anthropic_summary(pr, diffstat)
+  uri = URI('https://api.anthropic.com/v1/messages')
+  req = Net::HTTP::Post.new(uri)
+  req['x-api-key'] = AI_KEY
+  req['anthropic-version'] = '2023-06-01'
+  req['content-type'] = 'application/json'
+
+  system_prompt = <<~SYS
+    You write a personal website's changelog. Given a merged pull request, return
+    a single JSON object describing it for a general reader (no jargon, no file
+    names, no "this PR"). Focus on WHAT changed and WHY it mattered.
+
+    Return ONLY minified JSON with exactly these keys:
+      "title":    a short human headline, <= 60 chars, sentence case, no trailing period
+      "summary":  1-2 warm, plain-English sentences (<= 320 chars) on what & why
+      "category": one of #{CATEGORIES.join(', ')}
+    No markdown, no code fences, no extra keys.
+  SYS
+
+  body = (pr['body'] || '').gsub(/<[^>]+>/, ' ').gsub(/\s+/, ' ').strip[0, 1500]
+  user = <<~USR
+    PR ##{pr['number']}: #{pr['title']}
+    Merged: #{pr['merged_at']}
+    Files changed (#{diffstat[:count]}): #{diffstat[:files].join(', ')}
+    Net lines: +#{diffstat[:additions]} / -#{diffstat[:deletions]}
+
+    Description:
+    #{body.empty? ? '(none)' : body}
+  USR
+
+  payload = {
+    model: MODEL,
+    max_tokens: 400,
+    system: system_prompt,
+    messages: [{ role: 'user', content: user }]
+  }
+  req.body = JSON.dump(payload)
+
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+  unless res.is_a?(Net::HTTPSuccess)
+    warn "  ! Anthropic API #{res.code}: #{res.body.to_s[0, 200]} — skipping ##{pr['number']}"
+    return nil
+  end
+
+  text = JSON.parse(res.body).dig('content', 0, 'text').to_s
+  json = text[/\{.*\}/m]
+  return nil unless json
+
+  parsed = JSON.parse(json)
+  cat = parsed['category'].to_s.downcase
+  cat = 'feature' unless CATEGORIES.include?(cat)
+  {
+    'number'   => pr['number'],
+    'date'     => Time.parse(pr['merged_at']).strftime('%Y-%m-%d'),
+    'title'    => parsed['title'].to_s.strip,
+    'category' => cat,
+    'summary'  => parsed['summary'].to_s.strip,
+    'url'      => pr['html_url']
+  }
+rescue JSON::ParserError => e
+  warn "  ! Could not parse model output for ##{pr['number']}: #{e.message}"
+  nil
+end
+
+# --- fetch every merged PR (paginated) ------------------------------------
+
+def merged_pull_requests
+  prs = []
+  page = 1
+  loop do
+    batch = gh_get("/repos/#{REPO}/pulls",
+                   state: 'closed', per_page: 100, page: page,
+                   sort: 'updated', direction: 'desc')
+    break if batch.empty?
+
+    prs.concat(batch.select { |p| p['merged_at'] })
+    break if batch.size < 100
+
+    page += 1
+  end
+  prs
+end
+
+def diffstat_for(number)
+  files = gh_get("/repos/#{REPO}/pulls/#{number}/files", per_page: 100)
+  {
+    count: files.size,
+    files: files.map { |f| f['filename'] }.first(12),
+    additions: files.sum { |f| f['additions'].to_i },
+    deletions: files.sum { |f| f['deletions'].to_i }
+  }
+rescue StandardError
+  { count: 0, files: [], additions: 0, deletions: 0 }
+end
+
+# --- serialize back to a clean, diff-friendly YAML file --------------------
+
+HEADER = <<~HDR
+  # Changelog entries, generated from merged pull requests by
+  # scripts/generate_changelog.rb (each summary is a human-readable "what & why"
+  # written by Claude). This file is committed so the site build never calls any
+  # API. You can hand-edit any summary/title/category — the generator only adds
+  # NEW merged PRs and leaves existing entries untouched.
+  #
+  # Fields: number, date (YYYY-MM-DD), title, category, summary, url
+  # Categories: feature, fix, design, refactor, content, chore, polish
+HDR
+
+def yq(str)
+  '"' + str.to_s.gsub('\\', '\\\\\\\\').gsub('"', '\\"') + '"'
+end
+
+def wrap(text, indent)
+  words = text.split(/\s+/)
+  lines = []
+  cur = +''
+  words.each do |w|
+    if (cur.length + w.length + 1) > (80 - indent.length) && !cur.empty?
+      lines << cur
+      cur = +''
+    end
+    cur << (cur.empty? ? '' : ' ') << w
+  end
+  lines << cur unless cur.empty?
+  lines.map { |l| "#{indent}#{l}" }.join("\n")
+end
+
+def dump(entries)
+  out = +HEADER
+  out << "---\n"
+  entries.each do |e|
+    out << "- number: #{e['number']}\n"
+    out << "  date: '#{e['date']}'\n"
+    out << "  title: #{yq(e['title'])}\n"
+    out << "  category: #{e['category']}\n"
+    out << "  summary: >-\n"
+    out << wrap(e['summary'], '    ') << "\n"
+    out << "  url: #{e['url']}\n"
+    out << "\n"
+  end
+  out
+end
+
+# --- main ------------------------------------------------------------------
+
+existing = File.exist?(DATA_PATH) ? (YAML.safe_load(File.read(DATA_PATH)) || []) : []
+have = existing.map { |e| e['number'] }.to_set
+
+puts "Repo: #{REPO}  |  model: #{MODEL}  |  #{existing.size} existing entr#{existing.size == 1 ? 'y' : 'ies'}"
+
+merged = merged_pull_requests
+todo = FORCE ? merged : merged.reject { |p| have.include?(p['number']) }
+todo = todo.sort_by { |p| -p['number'] }
+todo = todo.first(LIMIT) if LIMIT && LIMIT.positive?
+
+if todo.empty?
+  puts 'Nothing new to summarize. Up to date.'
+  exit 0
+end
+
+abort 'ANTHROPIC_API_KEY is required to summarize new PRs.' if AI_KEY.nil? || AI_KEY.empty?
+
+puts "Summarizing #{todo.size} PR#{todo.size == 1 ? '' : 's'}..."
+by_number = existing.each_with_object({}) { |e, h| h[e['number']] = e }
+
+todo.each do |pr|
+  print "  ##{pr['number']} #{pr['title'][0, 50]}... "
+  entry = anthropic_summary(pr, diffstat_for(pr['number']))
+  next unless entry
+
+  by_number[entry['number']] = entry
+  puts "-> [#{entry['category']}] #{entry['title']}"
+end
+
+merged_entries = by_number.values.sort_by { |e| [e['date'], e['number']] }.reverse
+File.write(DATA_PATH, dump(merged_entries))
+puts "Wrote #{merged_entries.size} entries to #{DATA_PATH}"

--- a/styles.scss
+++ b/styles.scss
@@ -1,6 +1,10 @@
 ---
 ---
 
+// Font name comes from _config.yml (site.font.name) so the token, the
+// Google Fonts load, and the colophon all share one source of truth.
+$font-name: "{{ site.font.name }}";
+
 @import "../_sass/normalize";
 @import "../_sass/code";
 @import "../_sass/style";


### PR DESCRIPTION
A `/changelog` page that turns merged pull requests into a plain-English, month-grouped log of what I've been building on the site — and the tooling to keep it up to date.

## What's here

- **`_pages/changelog.md`** — the page. Groups entries by month with a tabular date gutter, category chips (`feature` / `fix` / `design` / `refactor` / `content` / `chore` / `polish`), a one/two-sentence summary, and a link to each PR. Styled with the existing design tokens, so it works in light and dark mode.
- **`_data/changelog.yml`** — the committed data source, seeded with all 20 merged PRs written up as human-readable "what & why" entries. Because the summaries live here, the Jekyll/Netlify build stays deterministic and never calls any API.
- **`scripts/generate_changelog.rb`** — an incremental generator (Ruby standard library only, no new gems). It fetches merged PRs from the GitHub API, sends each *new* one to Claude for a summary, and appends only PRs not already in the data file — so re-running is cheap and hand-edits are preserved.
- **`_pages/index.md`** — adds a "Changelog" link to the homepage *Elsewhere* list.

## Refreshing it later

```bash
export ANTHROPIC_API_KEY=sk-ant-...
export GITHUB_TOKEN=ghp_...        # optional, higher rate limits
ruby scripts/generate_changelog.rb # then commit _data/changelog.yml
```

## Design notes

- The data file is maintained newest-first (by date, then PR number) and the page groups in file order rather than re-sorting — Liquid's `sort` isn't stable, so entries merged on the same day would otherwise shuffle.
- Summaries are intentionally warm and first-person; they're plain data in `_data/changelog.yml` and easy to hand-edit.

## Testing

- `ruby -c scripts/generate_changelog.rb` and YAML parse of `_data/changelog.yml` both pass.
- Liquid sort/group logic simulated in Ruby to confirm month ordering and intra-day order.
- Page rendered against the real design tokens in light and dark mode to confirm styling.
- Note: `bundle exec jekyll build` couldn't run in the authoring environment (network policy blocks cloning the git-sourced `jekyll-last-modified-at` gem), so this deploy preview is the first full Jekyll render — please eyeball the rendered `/changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQX8Q4Gzst9u3VTEKBjH9A)_