### PR TITLE
Bake Readwise book highlights into notes at build time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ tags: [concerts]
 
 - **`bidirectional_links_generator.rb`** - Converts `[[wikilinks]]` to HTML, generates backlinks, creates `notes_graph.json` for visualization
 - **`photo_exif_generator.rb`** - Auto-creates `_photos/*.md` from images, extracts EXIF dates, reverse geocodes GPS coordinates via OpenStreetMap
+- **`readwise_transclusion.rb`** - Bakes Readwise book highlights into notes at build time. In a note, the native Obsidian embed `![[<Book Title> - Notes]]` is replaced with that book's highlights, fetched live from the Readwise API. Keeps the Obsidian vault pure markdown (no ids/frontmatter) and keeps Readwise notes out of the repo entirely.
+  - Requires `READWISE_TOKEN` in the build environment (same token as the `readwise-highlights` Netlify function; ensure it's exposed to builds, not just functions).
+  - Titles are matched to Readwise books ignoring case/emoji/punctuation. For titles that won't match cleanly, add `"Title": book_id` overrides in `_data/readwise_books.yml`.
+  - Fails gracefully: a missing token, no match, or an API error leaves an HTML comment and logs a warning — the build never breaks.
 
 ### Layouts
 

--- a/_data/readwise_books.yml
+++ b/_data/readwise_books.yml
@@ -1,0 +1,15 @@
+# Optional overrides for the Readwise highlight baker
+# (_plugins/readwise_transclusion.rb).
+#
+# Most books resolve automatically: the plugin matches the title in
+# `![[<Title> - Notes]]` against your Readwise library, ignoring case, emoji,
+# and punctuation. Only add an entry here when a title WON'T match cleanly —
+# e.g. the Obsidian note and the Readwise book title differ in wording, or two
+# books share a normalized title and you need to pin the right one.
+#
+# Format:  "<Title exactly as it appears before ' - Notes'>": <readwise_book_id>
+# Find the id in the book's Readwise URL (readwise.io/bookreview/<id>) or API.
+#
+# Example:
+#   "Fleishman Is in Trouble": 12345678
+#   "Jurassic Park": 23456789

--- a/_plugins/readwise_transclusion.rb
+++ b/_plugins/readwise_transclusion.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+require "uri"
+
+# Bakes Readwise book highlights into notes at BUILD time.
+#
+# Your Obsidian vault stays pure markdown: you write the native transclusion
+#
+#     ## Notes
+#
+#     ![[Fight Club - Notes]]
+#
+# which renders your local Readwise note inside Obsidian. Nothing Readwise-
+# specific (ids, plugins, frontmatter) is added to the vault, and the Readwise
+# notes themselves never need to live in this repo.
+#
+# On publish, this generator finds every `![[<Title> - Notes]]` embed, looks up
+# `<Title>` in your Readwise library via the API, fetches that book's
+# highlights, and replaces the embed with the highlights as markdown — so the
+# published page is self-contained, static HTML.
+#
+# Requirements:
+#   * ENV["READWISE_TOKEN"] available at build time (already set on Netlify for
+#     the readwise-highlights function; make sure it's exposed to builds too).
+#
+# Matching:
+#   * `<Title>` (the part before " - Notes") is matched to a Readwise book's
+#     title, normalized to ignore case, emoji, and punctuation.
+#   * For titles that won't match cleanly, add an override in
+#     _data/readwise_books.yml  ("Obsidian Title": readwise_book_id).
+#
+# Failure is always graceful: a missing token, no match, or an API error leaves
+# an HTML comment in place of the highlights and logs a warning — the build
+# never breaks.
+#
+# Runs at :high priority so it executes before BidirectionalLinksGenerator,
+# letting any wikilinks inside the fetched highlights resolve normally.
+module ReadwiseTransclusion
+  API_BASE = "https://readwise.io/api/v2"
+
+  # ![[Some Book - Notes]]  (whole-note embeds only; #headings / ^blocks and
+  # aliased embeds are intentionally left alone)
+  EMBED_PATTERN = /!\[\[([^\]|#\^]+?)\s*-\s*Notes\]\]/
+
+  class Generator < Jekyll::Generator
+    priority :high
+    safe false # needs network access at build time
+
+    def generate(site)
+      @token = ENV["READWISE_TOKEN"]
+      @overrides = build_overrides(site.data["readwise_books"])
+      @books_by_title = nil # lazily fetched on first lookup
+      @warned_no_token = false
+
+      collection = site.collections["notes"]
+      return unless collection
+
+      collection.docs.each { |doc| bake(doc) }
+    end
+
+    private
+
+    def bake(doc)
+      return unless doc.content =~ EMBED_PATTERN
+
+      doc.content = doc.content.gsub(EMBED_PATTERN) do
+        title = Regexp.last_match(1).strip
+        render(title, doc)
+      end
+    end
+
+    def render(title, doc)
+      unless @token
+        unless @warned_no_token
+          Jekyll.logger.warn "Readwise:", "READWISE_TOKEN not set — leaving embeds unresolved"
+          @warned_no_token = true
+        end
+        return placeholder("no READWISE_TOKEN at build time", title)
+      end
+
+      book_id = resolve_book_id(title)
+      unless book_id
+        Jekyll.logger.warn "Readwise:", "no book match for #{title.inspect} (#{doc.relative_path})"
+        return placeholder("no Readwise book matched", title)
+      end
+
+      highlights = fetch_highlights(book_id)
+      if highlights.nil?
+        Jekyll.logger.warn "Readwise:", "highlight fetch failed for #{title.inspect}"
+        return placeholder("Readwise fetch failed", title)
+      end
+      if highlights.empty?
+        Jekyll.logger.info "Readwise:", "no highlights for #{title.inspect}"
+        return placeholder("no highlights found", title)
+      end
+
+      Jekyll.logger.info "Readwise:", "baked #{highlights.size} highlight(s) for #{title.inspect}"
+      format_highlights(highlights)
+    end
+
+    # --- lookup -------------------------------------------------------------
+
+    def resolve_book_id(title)
+      key = normalize(title)
+      return @overrides[key] if @overrides.key?(key)
+
+      books_by_title[key]
+    end
+
+    def books_by_title
+      @books_by_title ||= begin
+        map = {}
+        each_book do |book|
+          next unless book["title"]
+
+          # First title wins on collision; overrides exist for disambiguation.
+          map[normalize(book["title"])] ||= book["id"]
+        end
+        map
+      end
+    end
+
+    # Walk the (paginated) list of all Readwise sources.
+    def each_book
+      url = "#{API_BASE}/books/?page_size=1000"
+      while url
+        data = api_get(url)
+        break unless data
+
+        Array(data["results"]).each { |book| yield book }
+        url = data["next"]
+      end
+    end
+
+    def fetch_highlights(book_id)
+      highlights = []
+      url = "#{API_BASE}/highlights/?book_id=#{book_id}&page_size=1000"
+      while url
+        data = api_get(url)
+        return nil unless data
+
+        highlights.concat(Array(data["results"]))
+        url = data["next"]
+      end
+      # Preserve reading order; highlights without a location sort last.
+      highlights.sort_by { |h| h["location"] || Float::INFINITY }
+    end
+
+    # --- formatting ---------------------------------------------------------
+
+    def format_highlights(highlights)
+      blocks = highlights.map do |h|
+        parts = [blockquote(h["text"])]
+        note = h["note"].to_s.strip
+        parts << "*#{note}*" unless note.empty?
+        parts.join("\n\n")
+      end
+      # Blank lines around the block keep markdown parsing clean.
+      "\n#{blocks.join("\n\n")}\n"
+    end
+
+    def blockquote(text)
+      text.to_s.strip.split("\n").map { |line| "> #{line}".rstrip }.join("\n")
+    end
+
+    def placeholder(reason, title)
+      "<!-- readwise: #{reason} for \"#{title}\" -->"
+    end
+
+    # --- helpers ------------------------------------------------------------
+
+    # Lowercase, strip anything that isn't a letter/number, collapse spaces.
+    # "🦖 Jurassic Park" and "Jurassic Park!" both normalize to "jurassic park".
+    def normalize(str)
+      str.to_s.downcase.gsub(/[^a-z0-9]+/, " ").strip
+    end
+
+    def build_overrides(data)
+      overrides = {}
+      return overrides unless data.is_a?(Hash)
+
+      data.each { |title, id| overrides[normalize(title)] = id }
+      overrides
+    end
+
+    def api_get(url, attempt: 1)
+      uri = URI(url)
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Token #{@token}"
+
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: true,
+                                 open_timeout: 10, read_timeout: 30) do |http|
+        http.request(request)
+      end
+
+      case response
+      when Net::HTTPSuccess
+        JSON.parse(response.body)
+      when Net::HTTPTooManyRequests
+        retry_after = response["Retry-After"].to_i
+        if attempt <= 3 && retry_after.between?(1, 60)
+          sleep(retry_after)
+          api_get(url, attempt: attempt + 1)
+        end
+      end
+    rescue StandardError => e
+      Jekyll.logger.warn "Readwise:", "API error (#{url}): #{e.message}"
+      nil
+    end
+  end
+end


### PR DESCRIPTION
## What & why

Lets a media-diet book note pull in its Readwise highlights **without putting anything Readwise-specific in the Obsidian vault or in the repo.**

In a note you keep the native Obsidian embed exactly as you write it today:

```markdown
## Notes

[[Fight Club - Notes]]
```

On publish, a new Jekyll generator finds `[[<Book Title> - Notes]]`, looks the title up in the Readwise library, fetches that book's highlights via the API, and replaces the embed with the highlights as static markdown. The vault stays pure, portable markdown (no ids, no site-only frontmatter), and the separate Readwise notes never need to live in the repo.

## Changes

- **`_plugins/readwise_transclusion.rb`** — the generator. Runs before the wikilink generator (so wikilinks inside highlights still resolve). Matches titles ignoring case/emoji/punctuation. Sorts highlights into reading order and renders annotations. **Fails gracefully**: a missing token, no title match, or an API error leaves an HTML comment and logs a warning rather than breaking the build.
- **`_data/readwise_books.yml`** — optional `"Title": book_id` overrides for titles that don't match cleanly (subtitles, wording differences, collisions).
- **`CLAUDE.md`** — documents the plugin and the build-env requirement.

## Required config

`READWISE_TOKEN` must be available **at build time** — the same token the `readwise-highlights` Netlify function already uses. In Netlify → Site config → Environment variables, confirm its scope includes **Builds**, not just Functions. If it isn't build-visible, the highlights simply don't bake (you'll see `<!-- readwise: no READWISE_TOKEN at build time -->` in the HTML) — no broken build.

## Testing

A full `jekyll build` couldn't run in the authoring environment (a GitHub-hosted gem dependency is blocked by egress policy), so the generator's logic was tested against a **mocked Readwise API** — all cases pass:

- Resolves `Fight Club`, sorts highlights by reading order, renders notes, fully replaces the embed
- Matches `🦖 Jurassic Park` from `[[Jurassic Park - Notes]]` (normalization)
- Captures multi-hyphen titles (`Filterworld - How Algorithms Flattened Culture`)
- Missing token / no match / API error → graceful HTML comment
- `_data` override maps a title → book_id
- Leaves unrelated embeds (`[[Movies.base#Ranking]]`, images) untouched

Field shapes (`document_title`, `text`, `note`, `location`) were confirmed against live Readwise data. **The real API round-trip only runs on Netlify — this deploy preview is the first true end-to-end test.** Check view-source on the Fight Club note for baked blockquotes (or a `<!-- readwise: ... -->` comment indicating what to fix).

## Caveats

- Highlights are baked per build (regenerated each deploy), not committed — permanence lasts as long as builds succeed.
- Only whole-note `[[Title - Notes]]` embeds are handled; `#heading`/`^block` and aliased embeds are intentionally left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174ZaE4ecdwUphJQfVVoLxy)_