### PR TITLE
Exclude Media Diet notes from homepage recent notes

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -21,7 +21,7 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
     {% assign all_notes = site.notes | sort: "created_at_timestamp" | reverse %}
     {% assign count = 0 %}
     {% for note in all_notes %}
-      {% unless note.path contains 'Concerts' %}
+      {% unless note.path contains 'Concerts' or note.path contains 'MediaDiet' %}
         {% if count < 5 %}
           <li>
             <span class="date">{{ note.created_at | date: "%b %Y" }}</span>


### PR DESCRIPTION
## What

Extend the homepage "Recent notes" filter in `_pages/index.md` to also skip `MediaDiet/` paths:

```liquid
{% unless note.path contains 'Concerts' or note.path contains 'MediaDiet' %}
```

## Why

The homepage recent-notes loop sorts all `site.notes` newest-first and only excluded `Concerts`. Media Diet notes live under `_notes/MediaDiet/`, which is part of `site.notes`, so they were always eligible — they just stayed off the homepage because their `created_at` fell back to an old git first-commit date (see `_plugins/last_modified_at_generator.rb`, which uses frontmatter `created`/`date` or the git add date).

The Media Diet redesign (#38/#39) deleted and re-added those note files, resetting their git-created dates to 2026-06-30. That made them the newest notes on the site, so they took over the top 5 recent notes on the homepage.

No homepage line was reverted — the media filter never existed here (the earlier `MediaDiet/` exclusion from #36 lived in `_pages/media.md` for a different list and was removed by #38). This adds the filter the homepage should have, so recent notes stays limited to garden notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAqSeZz7oMbWeAnrYUawcq)_