### PR TITLE
Backfill changelog, auto-update it, and tidy the homepage link

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,53 @@
+# Keeps _data/changelog.yml current by running scripts/generate_changelog.rb,
+# which summarizes any newly-merged PRs with Claude and commits the result.
+#
+# Requires one repository secret: ANTHROPIC_API_KEY
+#   Settings → Secrets and variables → Actions → New repository secret
+# GITHUB_TOKEN is provided automatically by Actions.
+name: Update changelog
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"   # every Monday at 12:00 UTC
+  push:
+    branches: [main]        # refresh right after a PR merges
+  workflow_dispatch: {}     # run on demand from the Actions tab
+
+# Let the job commit the regenerated data file back to the repo.
+permissions:
+  contents: write
+
+# Never run two updates at once (avoids racing pushes).
+concurrency:
+  group: update-changelog
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version   # stdlib only — no bundle install needed
+
+      - name: Summarize new merged PRs
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGELOG_REPO: ${{ github.repository }}
+        run: ruby scripts/generate_changelog.rb
+
+      - name: Commit if the changelog changed
+        run: |
+          if [[ -n "$(git status --porcelain _data/changelog.yml)" ]]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add _data/changelog.yml
+            # [skip ci] so this commit doesn't retrigger the push-based run
+            git commit -m "Update changelog [skip ci]"
+            git push
+          else
+            echo "No new merged PRs — changelog already up to date."
+          fi

--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -7,6 +7,67 @@
 # Fields: number, date (YYYY-MM-DD), title, category, summary, url
 # Categories: feature, fix, design, refactor, content, chore, polish
 ---
+- number: 45
+  date: '2026-07-01'
+  title: Keep the homepage recent notes to garden notes
+  category: fix
+  summary: >-
+    Filtered Media Diet entries out of the homepage "Recent notes" list — the
+    redesign had reset their file dates, so they'd jumped to the top and crowded
+    out the actual garden notes.
+  url: https://github.com/coopersmith/cooper-site/pull/45
+
+- number: 44
+  date: '2026-07-01'
+  title: Bake Readwise book highlights into notes at build time
+  category: feature
+  summary: >-
+    Taught the build to pull a book's Readwise highlights straight into its note
+    from a plain Obsidian embed, so the highlights show up on the site while the
+    Obsidian vault stays pure, portable markdown with nothing Readwise-specific
+    committed.
+  url: https://github.com/coopersmith/cooper-site/pull/44
+
+- number: 42
+  date: '2026-07-01'
+  title: Add this changelog
+  category: feature
+  summary: >-
+    Added the changelog you're reading — a plain-English, month-grouped log of
+    what I've been building, written up from each merged pull request — and
+    wired the site's font to a single config source while I was at it.
+  url: https://github.com/coopersmith/cooper-site/pull/42
+
+- number: 41
+  date: '2026-07-01'
+  title: Render Markdown in Readwise highlights
+  category: fix
+  summary: >-
+    Made Readwise highlights render their Markdown — bold, italics, and links —
+    instead of showing literal asterisks and bracket syntax, escaping the HTML
+    first so nothing unsafe slips through.
+  url: https://github.com/coopersmith/cooper-site/pull/41
+
+- number: 40
+  date: '2026-07-01'
+  title: Fix white highlight cards in dark mode
+  category: fix
+  summary: >-
+    Fixed the highlights page rendering unreadable white cards in dark mode — the
+    entry class collided with the code-syntax highlighter's styling — by renaming
+    it so highlights inherit the site's own light/dark blockquote look.
+  url: https://github.com/coopersmith/cooper-site/pull/40
+
+- number: 39
+  date: '2026-07-01'
+  title: Explore folding Concerts into Media Diet
+  category: feature
+  summary: >-
+    An exploration of making Media Diet the home for concerts via a "Live" filter
+    that swaps in an Artist / Venue / Date table, left running alongside the
+    existing Concerts page so it's easy to keep or drop.
+  url: https://github.com/coopersmith/cooper-site/pull/39
+
 - number: 38
   date: '2026-06-30'
   title: Redesign the Media Diet as a merged library

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -41,7 +41,6 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
     <li><a class="internal-link" href="{{ site.baseurl }}/travels/">Travels</a> <span class="desc">— adventures around the world.</span></li>
     <li><a class="internal-link" href="{{ site.baseurl }}/photos/">Visual Diary</a> <span class="desc">— my life through my lens.</span></li>
     <li><a class="internal-link" href="{{ site.baseurl }}/media/">Media Diet</a> <span class="desc">— what I'm reading, watching, and listening to.</span></li>
-    <li><a class="internal-link" href="{{ site.baseurl }}/changelog/">Changelog</a> <span class="desc">— what I've been building here, lately.</span></li>
     <li><a class="internal-link" href="{{ site.baseurl }}/about">About</a> <span class="desc">— the longer version, and where to find me.</span></li>
   </ul>
 </section>


### PR DESCRIPTION
Follow-up to #42. Keeps the changelog current, makes it self-maintaining, and removes the homepage link.

## Changes

- **Backfill `_data/changelog.yml`** — adds the six PRs merged after the initial seed (#39, #40, #41, #42, #44, #45), including a fittingly meta "Add this changelog" entry. The log is now current through #44.
- **Self-maintaining via GitHub Actions** — new `.github/workflows/update-changelog.yml` runs `scripts/generate_changelog.rb` on a weekly schedule, after each merge to `main`, and on demand, then commits any newly-summarized PRs. So the changelog stays current without anyone running the script by hand.
  - Ruby stdlib only, so no `bundle install` (sidesteps the git-sourced gem that can't be fetched in CI).
  - The auto-commit carries `[skip ci]` so it doesn't retrigger itself.
- **Remove Changelog from the homepage *Elsewhere* list** (`_pages/index.md`) — it stays linked from the footer (every page) and the colophon.

## Action required before the workflow can run

Add one repository secret so the Action can call Claude:

- **Settings → Secrets and variables → Actions → New repository secret**
- Name: `ANTHROPIC_API_KEY`, Value: your key

`GITHUB_TOKEN` is provided automatically. Until the secret exists, scheduled runs that find a new PR will fail loudly (by design) — runs with nothing new pass fine.

## Notes

- This branch was restarted from `main` after #42 merged, so it's a fresh PR, not a continuation of the merged one.
- `_data/changelog.yml` parses cleanly (26 entries) and the workflow YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQX8Q4Gzst9u3VTEKBjH9A)_