### PR TITLE
Add /notes/ landing page for the digital garden

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <nav class="site-foot" aria-label="Primary">
   <div class="site-foot__links">
-    <a class="internal-link" href="{{ site.baseurl }}/tableofcontents/">Notes</a>
+    <a class="internal-link" href="{{ site.baseurl }}/notes/">Notes</a>
     <a class="internal-link" href="{{ site.baseurl }}/photos/">Photos</a>
     <a class="internal-link" href="{{ site.baseurl }}/travels/">Travels</a>
     <a class="internal-link" href="{{ site.baseurl }}/media/">Media</a>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -21,7 +21,7 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
     {% assign all_notes = site.notes | sort: "created_at_timestamp" | reverse %}
     {% assign count = 0 %}
     {% for note in all_notes %}
-      {% unless note.path contains 'Concerts' or note.path contains 'MediaDiet' %}
+      {% unless note.path contains 'Concerts' or note.path contains 'MediaDiet' or note.path contains 'Travel' %}
         {% if count < 5 %}
           <li>
             <span class="date">{{ note.created_at | date: "%b %Y" }}</span>
@@ -32,7 +32,7 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
       {% endunless %}
     {% endfor %}
   </ul>
-  <p class="home-more"><a class="internal-link" href="{{ site.baseurl }}/tableofcontents/">See more →</a></p>
+  <p class="home-more"><a class="internal-link" href="{{ site.baseurl }}/notes/">See more →</a></p>
 </section>
 
 <section class="home-section">

--- a/_pages/notes.md
+++ b/_pages/notes.md
@@ -1,0 +1,36 @@
+---
+title: Notes
+description: A digital garden — guides, essays, and half-formed ideas I keep tending.
+permalink: /notes/
+---
+
+<h1>Notes</h1>
+<p class="subtitle">{{ page.description }}</p>
+
+<div class="index-toolbar">
+  <span class="sort-control">
+    <label for="notes-sort">Sort</label>
+    <select id="notes-sort" class="sort-select" data-sort-scope=".index-table" data-sort-item="tr">
+      <option value="date">Date</option>
+      <option value="az">A→Z</option>
+    </select>
+  </span>
+</div>
+
+{% assign all_notes = site.notes | sort: "created_at_timestamp" | reverse %}
+<table class="index-table">
+  {% for note in all_notes %}
+    {% unless note.path contains 'Concerts' or note.path contains 'MediaDiet' or note.path contains 'Travel' %}
+  <tr data-title="{{ note.title | downcase | escape }}" data-date="{{ note.created_at | date: '%Y-%m-%d' }}">
+    <td class="index-title"><a class="internal-link" href="{{ site.baseurl }}{{ note.url }}">{{ note.title }}</a></td>
+    <td class="index-date muted">{{ note.created_at | date: "%b %Y" }}</td>
+  </tr>
+    {% endunless %}
+  {% endfor %}
+</table>
+
+<script src="{{ site.baseurl }}/assets/js/sortable.js"></script>
+
+<style>
+  .wrapper { max-width: 46em; }
+</style>


### PR DESCRIPTION
Follow-up to #46. Gives the "Notes" nav item a real destination instead of the bare `/tableofcontents/` list.

## What's new
- **`/notes/` landing** — a sortable index (Date / A→Z) of the digital garden, built on the same `index-table` + toolbar pattern as `/travels/` and `/concerts/` for consistency.
- **Scoped to the garden:** excludes the collections that already have their own sections — Concerts (`/concerts/`), Media (`/media/`), and Travel (`/travels/`) — so each nav item is a distinct, non-overlapping bucket.

## Wiring
- Footer "Notes" link and the homepage "See more →" now point to `/notes/` instead of `/tableofcontents/`.
- Homepage "Recent notes" filter aligned to the same exclusions (added Travel), so it stays a true subset of `/notes/`.
- `/tableofcontents/` is left in place (a full dump of every note) but is no longer linked from primary nav.

## Files
- `_pages/notes.md` — new landing page
- `_includes/footer.html` — Notes → `/notes/`
- `_pages/index.md` — "See more" → `/notes/`; recent-notes filter excludes Travel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dokoSGLTxCiDHFywHrRiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019dokoSGLTxCiDHFywHrRiJ)_