### PR TITLE
Match footer nav to the homepage Elsewhere section

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,10 +1,9 @@
 <nav class="site-foot" aria-label="Primary">
   <div class="site-foot__links">
     <a class="internal-link" href="{{ site.baseurl }}/notes/">Notes</a>
-    <a class="internal-link" href="{{ site.baseurl }}/photos/">Photos</a>
     <a class="internal-link" href="{{ site.baseurl }}/travels/">Travels</a>
-    <a class="internal-link" href="{{ site.baseurl }}/media/">Media</a>
-    <a class="internal-link" href="{{ site.baseurl }}/concerts/">Concerts</a>
+    <a class="internal-link" href="{{ site.baseurl }}/photos/">Visual Diary</a>
+    <a class="internal-link" href="{{ site.baseurl }}/media/">Media Diet</a>
     <a class="internal-link" href="{{ site.baseurl }}/about">About</a>
   </div>
   <div class="site-foot__meta">© {{ site.time | date: "%Y" }} <a class="internal-link" href="{{ site.baseurl }}/about">{{ site.title }}</a> · <a class="internal-link" href="{{ site.baseurl }}/colophon">Colophon</a> · <a class="internal-link" href="{{ site.baseurl }}/changelog/">Changelog</a></div>


### PR DESCRIPTION
Aligns the footer nav with the homepage "Elsewhere" list.

## Changes
- **Dropped Concerts** from the footer nav.
- **Photos → Visual Diary** and **Media → Media Diet**, matching the "Elsewhere" labels.
- Footer nav row is now **Notes · Travels · Visual Diary · Media Diet · About**. Notes leads because the homepage lists it separately as "Recent notes," so it isn't in "Elsewhere."
- Colophon and Changelog stay in the small-print meta line (unchanged).

Note: Concerts is no longer linked from primary nav — `/concerts/` still exists and is reachable directly, just not surfaced in the footer.

## Files
- `_includes/footer.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dokoSGLTxCiDHFywHrRiJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019dokoSGLTxCiDHFywHrRiJ)_