### PR TITLE
Stack the media list rows on mobile

### DIFF
--- a/_pages/media.md
+++ b/_pages/media.md
@@ -325,6 +325,55 @@ Everything I've been reading, watching, listening to, and seeing live — in one
     /* Filter chips wrap awkwardly on narrow screens — use a dropdown */
     .media-filters .tag { display: none; }
     .media-filter-select { display: inline-block; }
+
+    /* ---- List view: on a phone the fixed 5-column table crushes the
+       title into a sliver while year + rating hug the far edge. Stack each
+       row instead: title on its own full-width line, then author/venue
+       (left) and rating (right) beneath it. ---- */
+    #media-library .media-list,
+    #media-library .media-list tbody,
+    #media-library .media-list tr,
+    #media-library .media-list td { display: block; }
+
+    #media-library .media-list tr {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      grid-template-areas:
+        "title  title"
+        "author rating";
+      column-gap: 0.8em;
+      row-gap: 0.1em;
+      padding: 0.7em 0;
+      border-bottom: 0.25px solid var(--color-border);
+    }
+    #media-library .media-list td { padding: 0; border: 0; width: auto; }
+
+    #media-library .media-list .index-title { grid-area: title; }
+    /* Drop the redundant type tag and the year — both are low-value here:
+       the type duplicates the filter, the year lives on the entry page. */
+    #media-library .media-list .index-meta:not(.muted),
+    #media-library .media-list .index-date.muted:not(.media-rating) { display: none; }
+    /* Bring author/venue back and let it fill the line instead of
+       collapsing to a sliver (grid items don't stretch these <td>s). */
+    #media-library .media-list .index-meta.muted {
+      grid-area: author;
+      display: block;
+      width: 100%;
+      min-width: 0;
+      padding-left: 0;
+      overflow: visible;
+      white-space: normal;
+      text-overflow: clip;
+      color: var(--color-text-tertiary);
+    }
+    #media-library .media-list .index-date.media-rating {
+      grid-area: rating;
+      display: block;
+      width: auto;
+      padding-left: 0;
+      text-align: right;
+      white-space: nowrap;
+    }
   }
 </style>
 


### PR DESCRIPTION
## Summary

Rescoped: the status-filter work this PR originally carried is **already on `main`** (`fee9451` + `76f6a08`, plus the Coop's 100 / covers redesign). To avoid duplicating and conflicting with that, this branch was reset onto latest `main` and now contains **only** the mobile list-layout cleanup that `main` doesn't have.

## Problem

On a phone the media **list** view uses a fixed 5-column table (`table-layout: fixed`). The title is squeezed into a narrow column while the year and rating hug the far edge — long titles wrap awkwardly and the row reads as cramped.

## Change

Inside the existing `@media (max-width: 600px)` block, restructure each list row into a stacked block:

- **Title** on its own full-width line.
- **Author / venue** (left) and **rating** (right) on the line beneath it.
- The **type tag** and **year** are dropped on mobile — the type duplicates the filter above the list, and the year lives on each entry's page.
- The author cell is forced to fill its grid track so short names ("Shea Serrano") stay on one line instead of collapsing to a sliver.

Scoped to `#media-library .media-list`, so the **desktop table, the JS, and main's status filter are all untouched**.

## Testing

Built the site and checked at 375px / 320px / desktop with real styles:

- Mobile list rows now stack cleanly (title, then author + rating); concert venues show correctly.
- Desktop list is byte-for-byte main (chips, Status/Sort/toggle, 5-column table).
- Main's status filter still works with the new CSS (All → 158, Queue → 12, Movies + Finished → 22; same counts on mobile).

## Note

`main`'s mobile toolbar shows the **type** dropdown unlabeled next to the labeled Status/Sort — a small consistency nit I left alone to keep this change to the list layout only. Happy to add a "Type" label as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)