### PR TITLE
Extend check-in staleness window to 1 week

### DIFF
--- a/_dev/location-debug.md
+++ b/_dev/location-debug.md
@@ -41,5 +41,5 @@ Production (`https://coopersmith.nyc`) — same params:
 - Without any param, the intro uses the live check-in:
   - NY state / NYC boroughs → NYC
   - Rhode Island or Massachusetts → Farm Coast
-  - anywhere else, checked in within the last 2 days → travelling
-  - stale (older than 2 days) or unknown → neutral
+  - anywhere else, checked in within the last week → travelling
+  - stale (older than 1 week) or unknown → neutral

--- a/assets/js/foursquare.js
+++ b/assets/js/foursquare.js
@@ -100,7 +100,7 @@ function travelPlace(loc) {
 function classifyCheckin(data) {
   if (!data || !data.createdAt) return null;
 
-  const STALE_AFTER_SECONDS = 2 * 24 * 60 * 60; // 2 days
+  const STALE_AFTER_SECONDS = 7 * 24 * 60 * 60; // 1 week
   const age = Date.now() / 1000 - data.createdAt;
   if (age > STALE_AFTER_SECONDS) return null;
 


### PR DESCRIPTION
Follow-up to #43.

The location-aware intro falls back to the neutral "I split my time between…" line once my most recent Foursquare check-in goes stale. That window was 2 days, which was tight enough that a normal gap between check-ins made the intro go neutral while I was plainly still home.

Bumps the window to **1 week** (`7 * 24 * 60 * 60`). Since I check in near-constantly while travelling and only go quiet at home, this keeps the home state sticky through those silences, while the travel line stays fresh on its own.

## Changes

- `assets/js/foursquare.js` — `STALE_AFTER_SECONDS` 2 days → 1 week.
- `_dev/location-debug.md` — update the staleness references to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0176GL3X4D96gUyosiQRvKWe)_