### PR TITLE
Media Diet: scope Coop's 100 to Movies, fix Status dropdown + toggle styling

### DIFF
--- a/_pages/media.md
+++ b/_pages/media.md
@@ -184,12 +184,17 @@ Everything I've been reading, watching, listening to, and seeing live — in one
 
   .media-toggle {
     display: inline-flex;
+    /* Fixed width + equal-flex halves so "List" and "Covers" occupy the
+       same width despite their different label lengths (the shorter label
+       just centres in its half). */
+    width: 10em;
     border: 1px solid var(--color-border);
     border-radius: 1em;
     overflow: hidden;
   }
   .media-view-btn {
     appearance: none; border: 0; background: transparent;
+    flex: 1 1 0; text-align: center;
     color: var(--color-text-tertiary); font: inherit; font-size: 0.78em;
     padding: 0.3em 0.85em; cursor: pointer;
     transition: background 0.15s ease, color 0.15s ease;

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -336,6 +336,13 @@ Everything I've been reading, watching, listening to, and seeing live — in one
     var sortSelect = document.getElementById('media-sort');
     var statusSelect = document.getElementById('media-status');
 
+    // The "Coop's 100" option is detached from the DOM when we're not scoped to
+    // Movies (see syncSortOption). It starts out `hidden` for the no-JS case;
+    // once JS owns it, presence in the <select> — not the attribute — controls
+    // visibility, so drop the attribute up front.
+    var rankedOpt = sortSelect ? sortSelect.querySelector('option[value="ranked"]') : null;
+    if (rankedOpt) rankedOpt.removeAttribute('hidden');
+
     var TYPES = { all: 1, book: 1, movie: 1, album: 1, concert: 1 };
     var VIEWS = { list: 1, covers: 1 };
     // 'ranked' (Coop's 100) is a movies-only sort that also subsets to ranked
@@ -372,18 +379,24 @@ Everything I've been reading, watching, listening to, and seeing live — in one
     }
 
     // "Coop's 100" (sort value 'ranked') only makes sense for movies, so its
-    // option is revealed only under the Movies filter. Returns true if it had
-    // to reset the sort because we left Movies while ranked was selected.
+    // option is present in the dropdown only under the Movies filter. We remove
+    // the node entirely rather than toggling `hidden`/`disabled`: browsers don't
+    // reliably honour `hidden` on <option>, which left it lingering as a
+    // confusing greyed-out entry. Returns true if it had to reset the sort
+    // because we left Movies while ranked was selected.
     function syncSortOption() {
-      if (!sortSelect) return false;
-      var opt = sortSelect.querySelector('option[value="ranked"]');
-      if (!opt) return false;
+      if (!sortSelect || !rankedOpt) return false;
       var allow = currentFilter === 'movie';
-      opt.hidden = !allow;
-      opt.disabled = !allow;
-      if (!allow && sortSelect.value === 'ranked') {
-        sortSelect.value = 'date';
-        return true;
+      var present = rankedOpt.parentNode === sortSelect;
+      if (allow && !present) {
+        sortSelect.appendChild(rankedOpt);
+      } else if (!allow && present) {
+        var wasSelected = sortSelect.value === 'ranked';
+        sortSelect.removeChild(rankedOpt);
+        if (wasSelected) {
+          sortSelect.value = 'date';
+          return true;
+        }
       }
       return false;
     }

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -30,7 +30,7 @@ Everything I've been reading, watching, listening to, and seeing live — in one
   <div class="media-toolbar-controls">
     <span class="sort-control">
       <label for="media-status">Status</label>
-      <select id="media-status">
+      <select id="media-status" class="sort-select">
         <option value="all">All</option>
         <option value="queue">Queue</option>
         <option value="active">Active</option>


### PR DESCRIPTION
Small polish pass on the Media Diet page.

## Changes

- **Scope "Coop's 100" to Movies.** The sort option was toggled between `hidden`/`disabled` and visible, but browsers (notably Safari) don't reliably honour `hidden` on `<option>` elements, so it lingered as a confusing greyed-out entry outside the Movies filter. Now the option node is detached from the `<select>` entirely unless the Movies filter is active, and re-attached under Movies. `?sort=ranked` deep links without Movies still fall back to Date as before.
- **Style the Status dropdown.** The `Status` (queue/active/finished) `<select>` added alongside the status filter never carried the `.sort-select` class, so it rendered as a raw browser-default dropdown next to the styled Sort pill. Added the class so it picks up the shared outlined-pill styling (same no-op sort wiring as the existing `.media-filter-select`).
- **Balance the List/Covers toggle.** `List` and `Covers` each sized to their own label width, leaving the two halves visibly unequal. Gave the toggle a fixed width and flexed each button to an equal half; the shorter label centres in its half.

## Verification

- `jekyll build` succeeds with no Liquid errors.
- Rendered output confirmed: ranked-option JS and `data-shelf` both present; Status select carries `sort-select`; toggle halves measure equal (80px each) with neither label overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPNL8gcBUL9rX3e74AWwU5)_