### PR TITLE
Add TV/Shows support to Media Diet

### DIFF
--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -16,6 +16,7 @@ layout: default
 {%- if page.author -%}{%- assign creator = page.author | join: ', ' -%}{%- assign creator_label = 'Author' -%}
 {%- elsif page.director -%}{%- assign creator = page.director | join: ', ' -%}{%- assign creator_label = 'Director' -%}
 {%- elsif page.artist -%}{%- assign creator = page.artist | join: ', ' -%}{%- assign creator_label = 'Artist' -%}
+{%- elsif page.creator -%}{%- assign creator = page.creator | join: ', ' -%}{%- assign creator_label = 'Creator' -%}
 {%- endif -%}
 {%- assign creator = creator | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip -%}
 
@@ -46,7 +47,7 @@ entries simply have no Completed fact. `created` (date added) is never used.{%- 
         {%- if cast != '' -%}<dt>Cast</dt><dd>{{ cast }}</dd>{%- endif -%}
         {%- if page.rating -%}
         <dt>Rating</dt>
-        <dd>{%- assign filled = page.rating -%}{%- if filled > 7 -%}{%- assign filled = 7 -%}{%- endif -%}{%- assign unfilled = 7 | minus: filled -%}<span class="rating-marks" title="{{ page.rating }}/7" aria-label="{{ page.rating }} out of 7">{%- if filled > 0 -%}{%- for i in (1..filled) -%}◆{%- endfor -%}{%- endif -%}{%- if unfilled > 0 -%}{%- for i in (1..unfilled) -%}◇{%- endfor -%}{%- endif -%}</span></dd>
+        <dd>{%- assign filled = page.rating | plus: 0 -%}{%- if filled > 7 -%}{%- assign filled = 7 -%}{%- endif -%}{%- assign unfilled = 7 | minus: filled -%}<span class="rating-marks" title="{{ page.rating }}/7" aria-label="{{ page.rating }} out of 7">{%- if filled > 0 -%}{%- for i in (1..filled) -%}◆{%- endfor -%}{%- endif -%}{%- if unfilled > 0 -%}{%- for i in (1..unfilled) -%}◇{%- endfor -%}{%- endif -%}</span></dd>
         {%- endif -%}
       </dl>
     </div>

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -17,12 +17,14 @@ Everything I've been reading, watching, listening to, and seeing live — in one
     <button type="button" class="tag is-active" data-filter="all">All</button>
     <button type="button" class="tag" data-filter="book">Books</button>
     <button type="button" class="tag" data-filter="movie">Movies</button>
+    <button type="button" class="tag" data-filter="show">TV</button>
     <button type="button" class="tag" data-filter="album">Albums</button>
     <button type="button" class="tag" data-filter="concert">Live</button>
     <select class="sort-select media-filter-select" aria-label="Filter by type">
       <option value="all">All</option>
       <option value="book">Books</option>
       <option value="movie">Movies</option>
+      <option value="show">TV</option>
       <option value="album">Albums</option>
       <option value="concert">Live</option>
     </select>
@@ -78,7 +80,8 @@ Everything I've been reading, watching, listening to, and seeing live — in one
       {% assign creator = '' %}
       {% if e.author %}{% assign creator = e.author | join: ', ' %}
       {% elsif e.director %}{% assign creator = e.director | join: ', ' %}
-      {% elsif e.artist %}{% assign creator = e.artist | join: ', ' %}{% endif %}
+      {% elsif e.artist %}{% assign creator = e.artist | join: ', ' %}
+      {% elsif e.creator %}{% assign creator = e.creator | join: ', ' %}{% endif %}
       {% assign creator = creator | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
       {% assign sorttitle = clean_title | downcase | strip %}
       {%- comment -%}The Completed column shows only when I finished something —
@@ -145,7 +148,8 @@ Everything I've been reading, watching, listening to, and seeing live — in one
       {% assign creator = '' %}
       {% if e.author %}{% assign creator = e.author | join: ', ' %}
       {% elsif e.director %}{% assign creator = e.director | join: ', ' %}
-      {% elsif e.artist %}{% assign creator = e.artist | join: ', ' %}{% endif %}
+      {% elsif e.artist %}{% assign creator = e.artist | join: ', ' %}
+      {% elsif e.creator %}{% assign creator = e.creator | join: ', ' %}{% endif %}
       {% assign creator = creator | replace: '[', '' | replace: ']', '' | replace: '  ', ' ' | strip %}
       {%- comment -%}shelf is a scalar for some collections (movies: "watched")
       and a YAML list for others (books: ["read"]/["queue"]); join reads both.
@@ -161,7 +165,7 @@ Everything I've been reading, watching, listening to, and seeing live — in one
           <span class="media-card-info">
             <span class="mci-title">{{ clean_title }}</span>
             {% if creator != '' %}<span class="mci-sub">{{ creator }}</span>{% endif %}
-            <span class="mci-foot"><span class="tag">{{ type }}</span>{% if e.year %}<span class="mci-year">{{ e.year }}</span>{% endif %}{%- if e.rating -%}{%- assign filled = e.rating -%}{%- if filled > 7 -%}{%- assign filled = 7 -%}{%- endif -%}{%- assign unfilled = 7 | minus: filled -%}<span class="mci-rating" title="{{ e.rating }}/7">{%- for i in (1..filled) -%}◆{%- endfor -%}{%- if unfilled > 0 -%}{%- for i in (1..unfilled) -%}◇{%- endfor -%}{%- endif -%}</span>{%- endif -%}</span>
+            <span class="mci-foot"><span class="tag">{{ type }}</span>{% if e.year %}<span class="mci-year">{{ e.year }}</span>{% endif %}{%- if e.rating -%}{%- assign filled = e.rating | plus: 0 -%}{%- if filled > 7 -%}{%- assign filled = 7 -%}{%- endif -%}{%- assign unfilled = 7 | minus: filled -%}<span class="mci-rating" title="{{ e.rating }}/7">{%- for i in (1..filled) -%}◆{%- endfor -%}{%- if unfilled > 0 -%}{%- for i in (1..unfilled) -%}◇{%- endfor -%}{%- endif -%}</span>{%- endif -%}</span>
           </span>
         </a>
       </li>
@@ -435,7 +439,7 @@ Everything I've been reading, watching, listening to, and seeing live — in one
     var rankedOpt = sortSelect ? sortSelect.querySelector('option[value="ranked"]') : null;
     if (rankedOpt) rankedOpt.removeAttribute('hidden');
 
-    var TYPES = { all: 1, book: 1, movie: 1, album: 1, concert: 1 };
+    var TYPES = { all: 1, book: 1, movie: 1, show: 1, album: 1, concert: 1 };
     var VIEWS = { list: 1, covers: 1 };
     // 'ranked' (Coop's 100) is a movies-only sort that also subsets to ranked
     // titles — see syncSortOption() / applyVisibility().


### PR DESCRIPTION
Adds first-class TV/Shows handling to the Media Diet, prompted by adding **Pluribus** (the first show).

## Changes

**TV filter on the index** — Shows already appeared under "All" and rendered with the media layout, but there was no way to filter to just TV. Added a **TV** filter chip + dropdown option (`data-filter="show"`) and registered `show` in the JS `TYPES` whitelist, so it filters, sorts, and deep-links (`?type=show`) like the other types. Slotted after Movies to group screen media.

**Creator byline** — Shows record the showrunner as `creator:` (e.g. Vince Gilligan), but every byline lookup only read `author`/`director`/`artist`. Added `creator` to the fallback chain in both the index "By" column and the entry-page byline (labelled "Creator" there).

**Rating hardening** — Coerce `rating` to a number (`| plus: 0`) before the star-mark comparison. A stray quoted rating in the vault (`rating: "6"` in `The Secret Agent.md`) was raising a Liquid `comparison of String with 7` error that failed the entire build; the coercion makes the deploy resilient to it.

## Verification

Local `jekyll build` exits 0. On the rendered output:
- Pluribus index row: **Pluribus · Show · Vince Gilligan · Dec 2025 · 5**
- Pluribus entry page: **Show** badge, **Creator: Vince Gilligan**, Year, Completed, Genre, Cast, Rating
- **TV** chip + dropdown option present; `TYPES` includes `show`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMazu51L9XUenvEHRWQM3J)_