### PR TITLE
Add scroll-reveal fade to Media Diet cover thumbnails

### DIFF
--- a/_pages/media.md
+++ b/_pages/media.md
@@ -287,6 +287,27 @@ Everything I've been reading, watching, listening to, and seeing live — in one
     grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
     gap: 1em 0.9em;
   }
+  /* Subtle fade-and-rise as covers scroll into view — mirrors the sitewide
+     text reveal (.fade-in-section). The class is added by JS, so with no JS
+     the covers render fully visible. */
+  .media-card.reveal-on-scroll {
+    opacity: 0;
+    transform: translateY(16px);
+    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+    will-change: opacity, transform;
+  }
+  .media-card.reveal-on-scroll.is-revealed {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .media-card.reveal-on-scroll {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+  }
+
   .media-card a {
     position: relative; display: block; text-decoration: none;
     color: var(--color-text-subtle); transition: transform 0.15s ease;
@@ -556,6 +577,38 @@ Everything I've been reading, watching, listening to, and seeing live — in one
     applyVisibility();
 
     ready = true;
+  })();
+
+  // ---- Scroll reveal for cover thumbnails ----
+  // Fade the cards in as they enter the viewport, matching the sitewide text
+  // animation. This runs independently of the load-time view: cards start
+  // hidden only after the class is applied here, so they reveal whether Covers
+  // is the initial view or you switch to it later. Cards hidden by a filter
+  // (display:none) never intersect, so they stay ready and reveal when shown.
+  (function () {
+    var lib = document.getElementById('media-library');
+    if (!lib || !('IntersectionObserver' in window)) return;
+    var cards = lib.querySelectorAll('.media-card');
+    if (!cards.length) return;
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      cards.forEach(function (c) { c.classList.add('reveal-on-scroll', 'is-revealed'); });
+      return;
+    }
+
+    var revealObserver = new IntersectionObserver(function (entries, observer) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-revealed');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+    cards.forEach(function (c) {
+      c.classList.add('reveal-on-scroll');
+      revealObserver.observe(c);
+    });
   })();
 </script>
 <script src="{{ site.baseurl }}/assets/js/sortable.js"></script>

--- a/assets/js/scroll-fade.js
+++ b/assets/js/scroll-fade.js
@@ -2,8 +2,15 @@ document.addEventListener('DOMContentLoaded', function() {
   // Check if user prefers reduced motion
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   
-  // Include all heading levels explicitly
-  const contentElements = document.querySelectorAll('h1, h2, h3, h4, h5, h6, p, img, ul, ol, hr');
+  // Include all heading levels explicitly. Skip anything inside the Media Diet
+  // covers grid: those thumbnails start life in a hidden (display:none) grid
+  // when List view loads first, which would make this observer mark them
+  // "already visible" before they're ever shown. The media page runs its own
+  // scroll-reveal for cards so they animate regardless of which view loads.
+  const contentElements = Array.prototype.filter.call(
+    document.querySelectorAll('h1, h2, h3, h4, h5, h6, p, img, ul, ol, hr'),
+    el => !el.closest('.media-grid')
+  );
   
   const fadeInOptions = {
     threshold: 0.2,


### PR DESCRIPTION
## What & why

The cover thumbnails on Media Diet now fade-and-rise into view on scroll, matching the subtle sitewide text animation.

**The bug:** The sitewide text reveal (`scroll-fade.js`) already matched the cover `<img>`s via its `img` selector — but the page loads **List** view first, so the Covers `<ul class="media-grid">` is `display:none` at page load. Hidden elements report a zero bounding-rect, so the observer marked every cover "already visible" before it was ever shown. Switching to Covers (where you tend to land on mobile) then revealed a flat, un-animated wall — the animation had already been spent.

## Changes

- **`_pages/media.md`** — a dedicated `IntersectionObserver` reveal for `.media-card` that runs regardless of which view loads first, plus matching CSS (`opacity: 0` → `1` with a 16px rise, 0.6s ease-out — same feel as the text fade). As a bonus, cards also animate in when you toggle to Covers or change a filter.
- **`assets/js/scroll-fade.js`** — excludes `.media-grid` descendants from the global text fader so the two mechanisms don't fight over the same thumbnails.

## Notes

- The hiding class is applied by JS, so **no-JS** visitors see all covers fully rendered.
- **`prefers-reduced-motion`** is honored (cards render visible, no transition).
- `bundle exec jekyll build` passes clean; both scripts pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnwHWLnWv1rJTNtxpDHuw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnwHWLnWv1rJTNtxpDHuw6)_