### PR TITLE
Rework listening-report entry points and copy

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,6 @@
     <a class="internal-link" href="{{ site.baseurl }}/travels/">Travels</a>
     <a class="internal-link" href="{{ site.baseurl }}/photos/">Visual Diary</a>
     <a class="internal-link" href="{{ site.baseurl }}/media/">Media Diet</a>
-    <a class="internal-link" href="{{ site.baseurl }}/listening">Listening</a>
     <a class="internal-link" href="{{ site.baseurl }}/highlights">Commonplace</a>
     <a class="internal-link" href="{{ site.baseurl }}/about">About</a>
   </div>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -63,7 +63,6 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
   <div id="recently-played">
     <p>Loading recently played tracks…</p>
   </div>
-  <p class="home-more"><a class="internal-link" href="{{ site.baseurl }}/listening">See what I've been listening to →</a></p>
   <div id="last-checkin"></div>
 </section>
 

--- a/_pages/listening.html
+++ b/_pages/listening.html
@@ -5,7 +5,7 @@ permalink: /listening
 ---
 
 <h1>Listening</h1>
-<p class="subtitle">What I've had on rotation, pulled live from Last.fm. Pick a window.</p>
+<p class="subtitle">What I've had on rotation, pulled live from Last.fm.</p>
 
 <div id="lr-toggle" class="lr-toggle" aria-label="Choose a time window"></div>
 

--- a/_pages/media.md
+++ b/_pages/media.md
@@ -7,7 +7,7 @@ permalink: /media/
 
 # Media Diet
 
-Everything I've been reading, watching, listening to, and seeing live — in one place.
+Everything I've been reading, watching, listening to, and seeing live. For a more detailed view into music, see my [last.fm listening report]({{ site.baseurl }}/listening){: .internal-link}.
 
 {% assign entries = site.notes | where_exp: "n", "n.cover" | where_exp: "n", "n.path contains 'MediaDiet/'" | sort: "created" | reverse %}
 {% assign concerts = site.notes | where_exp: "n", "n.tags contains 'concerts'" | sort: "Dates" | reverse %}

--- a/assets/js/lastfm.js
+++ b/assets/js/lastfm.js
@@ -45,7 +45,7 @@ function fetchCurrentTrack() {
         .then(data => {
             if (data.recenttracks && data.recenttracks.track && data.recenttracks.track.length > 0) {
                 const track = data.recenttracks.track[0];
-                
+
                 // Check if the track is currently playing
                 if (track['@attr'] && track['@attr'].nowplaying === 'true') {
                     const trackName = track.name;
@@ -63,11 +63,26 @@ function fetchCurrentTrack() {
                     }
                 }
             }
+            // "See more" goes last, after the now-playing sentence if there is one.
+            appendSeeMore();
         })
         .catch(error => {
             console.error("Error fetching current track from Last.fm:", error);
+            // The artists sentence still loaded, so keep the link.
+            appendSeeMore();
         });
 }
 
+// Append a "See more" link to the fuller /listening report as the final piece
+// of the "Lately" music line. Guarded so it's only ever added once.
+function appendSeeMore() {
+    const recentlyPlayedDiv = document.getElementById("recently-played");
+    const paragraph = recentlyPlayedDiv.querySelector('p');
+    if (!paragraph || paragraph.querySelector('.recently-see-more')) {
+        return;
+    }
+    paragraph.innerHTML += ` <a class="recently-see-more" href="/listening">See more &rarr;</a>`;
+}
+
 // Call the function when the page loads
-document.addEventListener('DOMContentLoaded', fetchTopArtists); 
+document.addEventListener('DOMContentLoaded', fetchTopArtists);


### PR DESCRIPTION
Follow-up tweaks to the `/listening` report (shipped in #66), adjusting how it's linked and its copy.

## Changes

- **Homepage** — removed the standalone "See what I've been listening to" link. Instead, `lastfm.js` now appends a **"See more →"** link to the end of the "Lately" music line. It lands after the top-artists sentence, and if a now-playing track comes in, it re-appends *after* that sentence (guarded so it's only added once).
- **Footer** — removed the Listening nav link.
- **Media Diet** — the report is now linked from the intro copy instead: *"…and seeing live. For a more detailed view into music, see my last.fm listening report."* Rendered as an internal link (no new tab).
- **Listening page** — trimmed "Pick a window" from the subtitle.

## Files

- `assets/js/lastfm.js` — append the "See more →" link after the music line / now-playing
- `_pages/index.md` — drop the standalone homepage link
- `_includes/footer.html` — remove the Listening nav link
- `_pages/media.md` — link to the report from the intro copy
- `_pages/listening.html` — subtitle copy

## Note

The homepage "See more →" href is hardcoded as `/listening` in `lastfm.js` (a static JS file, no Liquid templating) — correct while `baseurl` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTAcTuU3eEoVbgso9qEJ9)_