### PR TITLE
Doc: mark _notes as a build-time mirror of coops-site-publish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ This is a Jekyll-based digital garden/personal website with Obsidian-style wikil
 
 ### Collections
 
-- **`_notes/`** - Main content collection (digital garden notes). Supports `[[wikilinks]]` syntax for internal linking.
+- **`_notes/`** - Main content collection (digital garden notes). Supports `[[wikilinks]]` syntax for internal linking. **⚠️ Do not edit files in `_notes/` directly in this repo — they are a build-time mirror.** Notes are authored in Obsidian and live in the private `coopersmith/coops-site-publish` repo; that repo's `sync-to-site` GitHub Action copies them into `_notes/` on every publish, so any direct edit here is overwritten on the next sync. To change a note, edit it in `coops-site-publish`.
 - **`_photos/`** - Photo entries auto-generated from `assets/photos/` images via EXIF extraction.
 - **`_pages/`** - Static pages (about, travels, concerts, etc.)
 


### PR DESCRIPTION
## What

Adds a one-line guard to `CLAUDE.md`'s `_notes/` description noting that `_notes/` in this repo is now a **build-time mirror**, not a place to edit.

## Why

Notes are now authored in Obsidian in the private `coopersmith/coops-site-publish` repo. That repo's `sync-to-site` GitHub Action copies the notes into `cooper-site/_notes/` (via a deploy key) on every publish, which then triggers the Netlify build. Because the sync mirrors the source with `rsync --delete`, **any direct edit to `_notes/` in this repo is overwritten on the next publish.**

This note keeps future edits (from Claude Code sessions or a code editor) pointed at the real source, so nobody loses work editing the mirror by mistake.

## Scope

Docs only — one line in `CLAUDE.md`. No build or site behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvW9XpT4p6FZsFAiYXfWGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvW9XpT4p6FZsFAiYXfWGW)_