### PR TITLE
Prevent stray horizontal scroll on mobile

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -81,6 +81,15 @@ $font-name: 'Hanken Grotesk' !default;
   }
 }
 
+// On mobile the scroll container is the root <html> element, not <body>, so
+// clipping horizontal overflow on <body> alone doesn't stop the viewport from
+// panning sideways during a vertical scroll. Clip it on <html> too so any
+// element that pokes past the edge (negative-margin code blocks, the notes
+// graph, wide embeds) can't produce a stray horizontal scroll.
+html {
+  overflow-x: hidden;
+}
+
 body {
   background-color: var(--color-bg-primary);
   box-sizing: content-box;


### PR DESCRIPTION
## Problem

On mobile, scrolling vertically produced a "weird" horizontal scroll — the page could pan sideways during a normal vertical swipe.

## Cause

`_style.scss` already sets `overflow-x: hidden` on `body`, which is enough on desktop. But on mobile the viewport's scroll container is the root `<html>` element, not `<body>`, so clipping on `body` alone doesn't reliably constrain the viewport. Any element that pokes a few pixels past the edge (the negative-margin code blocks in `_code.scss`, the notes-graph SVG, wide embeds) then lets the whole page scroll horizontally.

## Fix

Add `overflow-x: hidden` to the root `<html>` element as well. With both `html` and `body` clipping, the viewport can't scroll horizontally regardless of which element overflows. Vertical scrolling is unaffected.

```scss
html {
  overflow-x: hidden;
}
```

## Verification

- `styles.scss` compiles cleanly.
- Headless-browser check at a 375px viewport: vertical scrolling works normally and a horizontal-pan attempt leaves `scrollX = 0` — no regression.
- The iOS-specific leak can't be reproduced in a desktop headless browser (desktop already propagates body's clip to the viewport), so please confirm on the Netlify deploy preview on an actual phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dsNGKbFC1H7rmB8ZfVX2M)_