### PR TITLE
Show recently-scrobbled tracks as now playing on homepage

### DIFF
--- a/assets/js/home-lately.js
+++ b/assets/js/home-lately.js
@@ -1,6 +1,29 @@
 // Homepage "Lately" music line: a sentence of recent top artists, the track
 // playing right now (if any), and a link to the fuller /listening report.
 // Uses the shared Last.fm client in lastfm-api.js.
+
+// How long after a scrobble we still call it "currently listening".
+//
+// Last.fm distinguishes a live "now playing" ping (track.updateNowPlaying,
+// flagged @attr.nowplaying) from a completed scrobble (track.scrobble, stamped
+// with a time). Apps like Spotify send the live ping; the Sonos plugin that
+// scrobbles radio (e.g. Radio FIP) only ever sends completed scrobbles, so it
+// would never satisfy a strict nowplaying check. Treating a fresh scrobble as
+// still-playing bridges that gap: on a continuous stream the previous track's
+// scrobble stays "current" until the next one lands, and when you actually stop
+// it lingers for at most this window before disappearing. Comfortably longer
+// than a typical song so continuous listening never blinks out mid-stream.
+const NOW_PLAYING_DECAY_MS = 10 * 60 * 1000; // 10 minutes
+
+// A track counts as "currently listening" if Last.fm flags it as now-playing,
+// or if it was scrobbled within the decay window above.
+function isCurrentlyListening(track) {
+  if (track["@attr"] && track["@attr"].nowplaying === "true") return true;
+  const uts = track.date && Number(track.date.uts);
+  if (!uts) return false;
+  return Date.now() - uts * 1000 <= NOW_PLAYING_DECAY_MS;
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   const el = document.getElementById("recently-played");
   if (!el) return;
@@ -21,7 +44,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     const data = await LASTFM.api("user.getrecenttracks", { limit: 1 });
     const track = data.recenttracks && data.recenttracks.track && data.recenttracks.track[0];
-    if (track && track["@attr"] && track["@attr"].nowplaying === "true") {
+    if (track && isCurrentlyListening(track)) {
       const sentence = ` Currently listening to <a href="${track.url}" target="_blank" rel="noopener">${track.name}</a> by ${track.artist["#text"]}.`;
       const existing = el.querySelector("p");
       if (existing) {


### PR DESCRIPTION
The homepage 'Lately' line only treated a track as currently listening
when Last.fm flagged it @attr.nowplaying, which comes from a live
updateNowPlaying ping. The Sonos plugin that scrobbles radio (e.g. Radio
FIP) only sends completed scrobbles, never the live ping, so it never
appeared.

Add a decay window: a track counts as currently listening if it's flagged
now-playing OR was scrobbled within the last 10 minutes. On a continuous
stream this keeps the previous scrobble 'current' until the next lands,
and lingers briefly after you stop.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JFqQXiqkAmSQkiDqwyuTA3