### PR TITLE
Home page intro updates

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -21,7 +21,7 @@ Glass:
 ## Now
 
 - Director of Product Design at [Asana](https://asana.com/features)
-- Splitting time between Brooklyn and our [1754 home](https://www.instagram.com/p/CSHlpbrHvX0/?utm_source=ig_web_copy_link&igsh=MzRlODBiNWFlZA) on the [Rhode Island Farm Coast](https://www.nytimes.com)
+- Splitting time between Brooklyn and our [ca. 1754 home](https://www.instagram.com/p/CSHlpbrHvX0/?utm_source=ig_web_copy_link&igsh=MzRlODBiNWFlZA) on the [Rhode Island Farm Coast](https://www.nytimes.com)
 - Finishing up some time off and preparing for my next adventure in [product design leadership](https://read.cv)
 - Micro-roasting coffee from my barn and prototyping a small business at [Farm Coast Coffee](https://www.farmcoastcoffee.com)
 - Rarely without my camera, capturing [urban geometry](https://glass.photo/coop/series/23JMDL7SdFbichhEXDLYLC-urban-geometry), life with our new [chocolate lab Henry](https://glass.photo/coop/series/DwvX0G2qYfvLJESKQxL0b-life-with-henry), and [other adventures](https://glass.photo/coop)

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -22,10 +22,8 @@ I'm currently traveling<span id="travel-place"></span> — follow the adventures
 When I'm in NYC, I'm a Director of Product Design at Asana, where I lead design across our Mobile and Coordinate teams for our Agentic Work Management. I have over a decade of experience building products and teams at [[Lyft]], [[Twitter]], [[Foursquare]] and [[Asana]].
 {: #intro-nyc}
 
-When I'm in Rhode Island, I look after our [[White Homestead|1754 farmhouse]] and work remotely for Asana. I roast coffee in my barn and run a small micro-roastery called [Farm Coast Coffee](https://farmcoastcoffee.square.site) as a fun side project.
+When I'm in Rhode Island, I look after our [[White Homestead|ca. 1754 farmhouse]] and work remotely for Asana. I roast coffee in my barn and run a small micro-roastery called [Farm Coast Coffee](https://farmcoastcoffee.square.site) as a fun side project.
 {: #intro-ri}
-
-I'm rarely without a camera, and share my adventures on [Instagram](https://www.instagram.com/coopersmith) and [Glass](https://glass.photo/coop). 
 
 {% comment %}
 Recent notes — temporarily hidden, bring back later.

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -19,14 +19,18 @@ I'm currently on Rhode Island's [Farm Coast](https://www.nytimes.com/2023/10/09/
 I'm currently traveling<span id="travel-place"></span> — follow the adventures on [Instagram](https://www.instagram.com/coopersmith).
 {: #intro-lead-travel .loc-alt}
 
-When I'm in NYC, I'm a Director of Product Design at Asana, where I lead design across our Mobile and Coordinate teams for Asana's Agentic Work Management. I have over a decade of experience building products and teams at [[Lyft]], [[Twitter]], [[Foursquare]] and [[Asana]].
+When I'm in NYC, I'm a Director of Product Design at Asana, where I lead design across our Mobile and Coordinate teams for our Agentic Work Management. I have over a decade of experience building products and teams at [[Lyft]], [[Twitter]], [[Foursquare]] and [[Asana]].
 {: #intro-nyc}
 
-When I'm in Rhode Island, I look after our 1754 farmhouse and work remotely for Asana. I roast coffee in my barn and run a small micro-roastery called [Farm Coast Coffee](https://farmcoastcoffee.square.site) as a fun side project.
+When I'm in Rhode Island, I look after our [[White Homestead|1754 farmhouse]] and work remotely for Asana. I roast coffee in my barn and run a small micro-roastery called [Farm Coast Coffee](https://farmcoastcoffee.square.site) as a fun side project.
 {: #intro-ri}
 
 I'm rarely without a camera, and share my adventures on [Instagram](https://www.instagram.com/coopersmith) and [Glass](https://glass.photo/coop). 
 
+{% comment %}
+Recent notes — temporarily hidden, bring back later.
+{% endcomment %}
+{% comment %}
 <section class="home-section">
   <p class="home-label">Recent notes</p>
   <ul class="home-list">
@@ -46,6 +50,7 @@ I'm rarely without a camera, and share my adventures on [Instagram](https://www.
   </ul>
   <p class="home-more"><a class="internal-link" href="{{ site.baseurl }}/notes/">See more →</a></p>
 </section>
+{% endcomment %}
 
 <section class="home-section">
   <p class="home-label">Elsewhere</p>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -19,7 +19,7 @@ I'm currently on Rhode Island's [Farm Coast](https://www.nytimes.com/2023/10/09/
 I'm currently traveling<span id="travel-place"></span> — follow the adventures on [Instagram](https://www.instagram.com/coopersmith).
 {: #intro-lead-travel .loc-alt}
 
-When I'm in NYC, I'm a Director of Product Design at Asana, where I lead design for our Align and Mobile organizations. I have over a decade of experience building products and teams at [[Lyft]], [[Twitter]], [[Foursquare]] and [[Asana]].
+When I'm in NYC, I'm a Director of Product Design at Asana, where I lead design across our Mobile and Coordinate teams for Asana's Agentic Work Management. I have over a decade of experience building products and teams at [[Lyft]], [[Twitter]], [[Foursquare]] and [[Asana]].
 {: #intro-nyc}
 
 When I'm in Rhode Island, I look after our 1754 farmhouse and work remotely for Asana. I roast coffee in my barn and run a small micro-roastery called [Farm Coast Coffee](https://farmcoastcoffee.square.site) as a fun side project.


### PR DESCRIPTION
Updates to the primary index view (`_pages/index.md`), plus one matching change in About.

## Changes

**Current role.** The NYC intro line now reads "…where I lead design across our Mobile and Coordinate teams for our Agentic Work Management," replacing "Align and Mobile organizations."

**Farmhouse link.** "ca. 1754 farmhouse" on the Rhode Island line now links to the White Homestead note via `[[White Homestead|ca. 1754 farmhouse]]`.

**Build date qualified.** The house's 1754 date comes from the tax assessor's year-built field, which the note documents as unsourced — the Assessor confirmed in 2026 that no internal documentation supports it, and the plausible construction window is roughly 1720–1790. Both the home intro and the About "Now" list now say "ca. 1754" rather than stating the year flat.

**Recent notes hidden.** The section is wrapped in `{% raw %}{% comment %}…{% endcomment %}{% endraw %}` rather than an HTML comment, since Liquid inside an HTML comment still executes. The markup is untouched inside, so restoring it later means deleting the two wrapper lines.

**Camera line removed.** Dropped "I'm rarely without a camera, and share my adventures on Instagram and Glass." from the home intro.

## Verification

`jekyll build` runs clean. Confirmed in the built `_site/index.html`: the wikilink resolves to `/white-homestead-publish`, "Recent notes" no longer renders, and the camera line is gone. The remaining build warnings (duplicate `:slug.jpeg` destinations from concert attachments, missing `READWISE_TOKEN`) are pre-existing and unrelated.

## Note

The White Homestead note's source file is `White Homestead publish.md`, so its public URL is `/white-homestead-publish` — the "publish" leaks into the path. The link works as-is; a clean `/white-homestead` would mean renaming the file in `coops-site-publish`, since `_notes/` here is a build-time mirror. The wikilink matches on title and would survive that rename.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrTvDmeEuM66UQ4k1oSF7Q)_