### PR TITLE
Show "work remotely for Asana" only when I'm actually in Rhode Island

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -22,7 +22,7 @@ I'm currently traveling<span id="travel-place"></span> — follow the adventures
 When I'm in NYC, I'm a Director of Product Design at Asana, where I lead design across our Mobile and Coordinate teams for our Agentic Work Management. I have over a decade of experience building products and teams at [[Lyft]], [[Twitter]], [[Foursquare]] and [[Asana]].
 {: #intro-nyc}
 
-When I'm in Rhode Island, I look after our [[White Homestead|ca. 1754 farmhouse]] and work remotely for Asana. I roast coffee in my barn and run a small micro-roastery called [Farm Coast Coffee](https://farmcoastcoffee.square.site) as a fun side project.
+When I'm in Rhode Island, I look after our [[White Homestead|ca. 1754 farmhouse]]<span id="intro-ri-remote" class="loc-alt"> and work remotely for Asana</span>. I roast coffee in my barn and run a small micro-roastery called [Farm Coast Coffee](https://farmcoastcoffee.square.site) as a fun side project.
 {: #intro-ri}
 
 {% comment %}

--- a/assets/js/foursquare.js
+++ b/assets/js/foursquare.js
@@ -172,6 +172,12 @@ function applyIntroLocation(result) {
     leadNeutral.classList.add('loc-alt');
     leadActive.classList.remove('loc-alt');
   }
+
+  // "…and work remotely for Asana" only earns its place when I'm actually in
+  // Rhode Island; read from Brooklyn it claims I'm remote from the office I'm
+  // sitting in. Hidden by default, so travel and the neutral state drop it too.
+  const remote = document.getElementById('intro-ri-remote');
+  if (remote) remote.classList.toggle('loc-alt', bucket !== 'ri');
 }
 
 // Reflect my most recent check-in in the intro.


### PR DESCRIPTION
The Rhode Island paragraph on the home page renders in every location state — `applyIntroLocation` only reorders the two paragraphs and swaps the lead line, it never hides either one. So "and work remotely for Asana" was on the page even when the intro said "I'm currently in Brooklyn, NY," claiming I was remote from the office I was sitting in.

## Changes

**`_pages/index.md`** — the phrase is now wrapped in `<span id="intro-ri-remote" class="loc-alt"> and work remotely for Asana</span>`. The `loc-alt` class is the existing hidden-by-default hook the alternate lead lines already use, so this needs no new CSS. The sentence's period stays outside the span.

**`assets/js/foursquare.js`** — `applyIntroLocation` toggles the span off for any bucket other than `ri`, alongside the existing lead-line swap.

Hidden by default means the neutral state (no check-in data, or the Foursquare call fails) drops the phrase as well. That's deliberate: a missing clause reads fine, whereas the wrong-place claim is the exact thing this fixes.

## Verification

Built locally and checked all four states through the `?loc=` debug hook. Rendered text of the RI paragraph:

| State | RI paragraph |
|---|---|
| neutral | …our ca. 1754 farmhouse. I roast coffee… |
| nyc | …our ca. 1754 farmhouse. I roast coffee… |
| **ri** | …our ca. 1754 farmhouse **and work remotely for Asana**. I roast coffee… |
| travel | …our ca. 1754 farmhouse. I roast coffee… |

Branch was restarted from `main` after #81 merged, so this is a single commit on top of current `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrTvDmeEuM66UQ4k1oSF7Q)_